### PR TITLE
feat(cortex): M2 Ingestion Pipeline

### DIFF
--- a/src/cortex/__mocks__/MockTimeProvider.ts
+++ b/src/cortex/__mocks__/MockTimeProvider.ts
@@ -1,0 +1,10 @@
+export interface TimeProvider {
+  now(): number;
+  isoString(): string;
+}
+
+export class MockTimeProvider implements TimeProvider {
+  constructor(private fixedTime: number) {}
+  now(): number { return this.fixedTime; }
+  isoString(): string { return new Date(this.fixedTime).toISOString(); }
+}

--- a/src/cortex/bridge/AetherIndexBridge.test.ts
+++ b/src/cortex/bridge/AetherIndexBridge.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AetherIndexBridge } from './AetherIndexBridge';
+
+interface MockIndexer {
+  indexDocument: ReturnType<typeof vi.fn>;
+  deleteDocument: ReturnType<typeof vi.fn>;
+}
+
+function makeIndexer(): MockIndexer {
+  return {
+    indexDocument: vi.fn().mockResolvedValue({ chunks: 5, status: 'ok' }),
+    deleteDocument: vi.fn().mockResolvedValue({ status: 'ok' }),
+  };
+}
+
+describe('AetherIndexBridge.onDocumentSaved', () => {
+  let indexer: MockIndexer;
+  let bridge: AetherIndexBridge;
+
+  beforeEach(() => {
+    indexer = makeIndexer();
+    bridge = new AetherIndexBridge({ indexer: indexer as never });
+  });
+
+  it('should_call_indexDocument_when_document_is_saved', async () => {
+    const event = { type: 'saved', docId: 'doc-1', path: '/aether/doc-1.md', mimeType: 'text/markdown' };
+    await bridge.onDocumentSaved(event);
+    expect(indexer.indexDocument).toHaveBeenCalledWith({ docId: 'doc-1', path: '/aether/doc-1.md', mimeType: 'text/markdown' });
+  });
+
+  it('should_return_indexing_result_on_success', async () => {
+    const event = { type: 'saved', docId: 'doc-1', path: '/aether/doc-1.md', mimeType: 'text/markdown' };
+    const result = await bridge.onDocumentSaved(event);
+    expect(result.status).toBe('ok');
+    expect(result.chunks).toBe(5);
+  });
+
+  it('should_not_index_if_event_type_is_not_saved', async () => {
+    const event = { type: 'opened', docId: 'doc-1', path: '/aether/doc-1.md', mimeType: 'text/markdown' };
+    await bridge.onDocumentSaved(event);
+    expect(indexer.indexDocument).not.toHaveBeenCalled();
+  });
+
+  it('should_propagate_indexer_errors', async () => {
+    indexer.indexDocument.mockRejectedValueOnce(new Error('RuVector timeout'));
+    const event = { type: 'saved', docId: 'doc-x', path: '/aether/doc-x.md', mimeType: 'text/markdown' };
+    await expect(bridge.onDocumentSaved(event)).rejects.toThrow('RuVector timeout');
+  });
+});
+
+describe('AetherIndexBridge.onDocumentDeleted', () => {
+  let indexer: MockIndexer;
+  let bridge: AetherIndexBridge;
+
+  beforeEach(() => {
+    indexer = makeIndexer();
+    bridge = new AetherIndexBridge({ indexer: indexer as never });
+  });
+
+  it('should_call_deleteDocument_when_document_is_deleted', async () => {
+    await bridge.onDocumentDeleted({ docId: 'doc-1' });
+    expect(indexer.deleteDocument).toHaveBeenCalledWith({ docId: 'doc-1' });
+  });
+
+  it('should_not_throw_if_document_was_not_indexed', async () => {
+    indexer.deleteDocument.mockResolvedValueOnce({ status: 'not_found' });
+    await expect(bridge.onDocumentDeleted({ docId: 'phantom' })).resolves.not.toThrow();
+  });
+});

--- a/src/cortex/bridge/AetherIndexBridge.ts
+++ b/src/cortex/bridge/AetherIndexBridge.ts
@@ -1,0 +1,64 @@
+export interface IndexRequest {
+  docId: string;
+  path: string;
+  mimeType: string;
+}
+
+export interface IndexResult {
+  status: 'ok' | 'not_found' | 'error';
+  chunks?: number;
+}
+
+export interface DocumentIndexer {
+  indexDocument(req: IndexRequest): Promise<IndexResult>;
+  deleteDocument(req: { docId: string }): Promise<IndexResult>;
+}
+
+export interface DocumentSavedEvent {
+  type: string;
+  docId: string;
+  path: string;
+  mimeType: string;
+}
+
+interface AetherIndexBridgeOptions {
+  indexer: DocumentIndexer;
+}
+
+/**
+ * Puente entre los eventos de Aether (notas/documentos) y el indexador RuVector.
+ *
+ * Escucha eventos del sistema de archivos de Aether y delega en el indexador
+ * para mantener el índice vectorial sincronizado con los documentos del usuario.
+ */
+export class AetherIndexBridge {
+  private readonly indexer: DocumentIndexer;
+
+  constructor({ indexer }: AetherIndexBridgeOptions) {
+    this.indexer = indexer;
+  }
+
+  /**
+   * Maneja el evento "documento guardado" en Aether.
+   * Solo indexa si el tipo de evento es "saved".
+   */
+  async onDocumentSaved(event: DocumentSavedEvent): Promise<IndexResult> {
+    if (event.type !== 'saved') {
+      return { status: 'ok' };
+    }
+
+    return this.indexer.indexDocument({
+      docId: event.docId,
+      path: event.path,
+      mimeType: event.mimeType,
+    });
+  }
+
+  /**
+   * Maneja el evento "documento eliminado" en Aether.
+   * Elimina el documento del índice vectorial.
+   */
+  async onDocumentDeleted(event: { docId: string }): Promise<void> {
+    await this.indexer.deleteDocument({ docId: event.docId });
+  }
+}

--- a/src/cortex/subprocess/SubprocessAdapter.test.ts
+++ b/src/cortex/subprocess/SubprocessAdapter.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SubprocessAdapter } from './SubprocessAdapter';
+import type { IPCMessage } from '../ipc/IPCProtocol';
+
+/** Stub mínimo de un subproceso IPC */
+function makeMockTransport() {
+  const handlers = new Map<string, (msg: IPCMessage) => IPCMessage>();
+  return {
+    send: vi.fn(async (msg: IPCMessage): Promise<IPCMessage> => {
+      const h = handlers.get(msg.id);
+      return h ? h(msg) : { id: msg.id, status: 'error', error: 'no handler' };
+    }),
+    onReady: vi.fn().mockResolvedValue(undefined),
+    onExit: vi.fn(),
+    registerHandler: (id: string, fn: (m: IPCMessage) => IPCMessage) => handlers.set(id, fn),
+  };
+}
+
+describe('SubprocessAdapter — Docling (OCR)', () => {
+  let transport: ReturnType<typeof makeMockTransport>;
+  let adapter: SubprocessAdapter;
+
+  beforeEach(() => {
+    transport = makeMockTransport();
+    adapter = new SubprocessAdapter({ name: 'docling', transport: transport as never });
+  });
+
+  it('should_send_ocr_request_and_return_chunks', async () => {
+    transport.send.mockResolvedValueOnce({
+      id: 'req-1', status: 'ok', data: { chunks: ['Texto extraído del PDF'] },
+    });
+
+    const result = await adapter.request({ id: 'req-1', action: 'ocr', payload: { path: '/doc.pdf' } });
+    expect(result.status).toBe('ok');
+    expect((result.data as Record<string, unknown>).chunks).toHaveLength(1);
+  });
+
+  it('should_throw_on_error_response', async () => {
+    transport.send.mockResolvedValueOnce({
+      id: 'req-2', status: 'error', error: 'file not found',
+    });
+
+    await expect(
+      adapter.request({ id: 'req-2', action: 'ocr', payload: { path: '/missing.pdf' } })
+    ).rejects.toThrow('file not found');
+  });
+
+  it('should_throw_on_timeout', async () => {
+    transport.send.mockImplementationOnce(() => new Promise(() => {})); // nunca resuelve
+
+    await expect(
+      adapter.request({ id: 'req-3', action: 'ocr', payload: {} }, { timeoutMs: 50 })
+    ).rejects.toThrow('timeout');
+  });
+});
+
+describe('SubprocessAdapter — Whisper (transcripción)', () => {
+  let transport: ReturnType<typeof makeMockTransport>;
+  let adapter: SubprocessAdapter;
+
+  beforeEach(() => {
+    transport = makeMockTransport();
+    adapter = new SubprocessAdapter({ name: 'whisper', transport: transport as never });
+  });
+
+  it('should_send_transcribe_request_and_return_text', async () => {
+    transport.send.mockResolvedValueOnce({
+      id: 'req-4', status: 'ok', data: { text: 'El teorema de Bayes establece...' },
+    });
+
+    const result = await adapter.request({ id: 'req-4', action: 'transcribe', payload: { path: '/tmp/audio.wav' } });
+    expect(result.status).toBe('ok');
+    expect((result.data as Record<string, unknown>).text).toContain('Bayes');
+  });
+
+  it('should_include_subprocess_name_in_timeout_error', async () => {
+    transport.send.mockImplementationOnce(() => new Promise(() => {}));
+
+    await expect(
+      adapter.request({ id: 'req-5', action: 'transcribe', payload: {} }, { timeoutMs: 50 })
+    ).rejects.toThrow('whisper');
+  });
+});

--- a/src/cortex/subprocess/SubprocessAdapter.ts
+++ b/src/cortex/subprocess/SubprocessAdapter.ts
@@ -1,0 +1,66 @@
+import type { IPCMessage } from '../ipc/IPCProtocol';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export interface AdapterRequest {
+  id: string;
+  action: string;
+  payload: Record<string, unknown>;
+}
+
+export interface RequestOptions {
+  timeoutMs?: number;
+}
+
+export interface SubprocessTransport {
+  send(msg: IPCMessage): Promise<IPCMessage>;
+  onReady(): Promise<void>;
+}
+
+interface SubprocessAdapterOptions {
+  name: string;
+  transport: SubprocessTransport;
+}
+
+/**
+ * Adaptador genérico para subprocesos IPC (Docling, Whisper, RuVector).
+ *
+ * Encapsula el protocolo de request/response con timeout configurable.
+ * Los tests unitarios inyectan un transport mock; en producción se usa
+ * el transport real que gestiona el stdio del subproceso.
+ */
+export class SubprocessAdapter {
+  private readonly name: string;
+  private readonly transport: SubprocessTransport;
+
+  constructor({ name, transport }: SubprocessAdapterOptions) {
+    this.name = name;
+    this.transport = transport;
+  }
+
+  /**
+   * Envía una operación al subproceso y espera la respuesta.
+   * Lanza si el status es "error" o si se supera el timeout.
+   */
+  async request(req: AdapterRequest, opts: RequestOptions = {}): Promise<IPCMessage> {
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    const msg: IPCMessage = {
+      id: req.id,
+      status: 'ok', // campo requerido por IPCMessage; el subproceso lo sobrescribe en la respuesta
+      data: { action: req.action, ...req.payload },
+    };
+
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`[${this.name}] timeout after ${timeoutMs}ms`)), timeoutMs)
+    );
+
+    const response = await Promise.race([this.transport.send(msg), timeoutPromise]);
+
+    if (response.status === 'error') {
+      throw new Error(response.error ?? `[${this.name}] unknown error`);
+    }
+
+    return response;
+  }
+}

--- a/src/cortex/wav/WavManager.test.ts
+++ b/src/cortex/wav/WavManager.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Volume } from 'memfs';
+import { WavManager } from './WavManager';
+import { MockTimeProvider } from '../__mocks__/MockTimeProvider';
+
+const WAV_CONTENT = Buffer.from('RIFF....WAVEfmt ');
+
+describe('WavManager — deleteAfterTranscription', () => {
+  let vol: InstanceType<typeof Volume>;
+  let wav: WavManager;
+
+  beforeEach(() => {
+    vol = new Volume();
+    vol.mkdirSync('/tmp', { recursive: true });
+    wav = new WavManager({ fs: vol as never, time: new MockTimeProvider(Date.now()) });
+  });
+
+  it('should_delete_wav_file_after_successful_transcription', async () => {
+    vol.writeFileSync('/tmp/recording.wav', WAV_CONTENT);
+    await wav.deleteAfterTranscription('/tmp/recording.wav');
+    expect(vol.existsSync('/tmp/recording.wav')).toBe(false);
+  });
+
+  it('should_not_throw_if_file_already_absent', async () => {
+    await expect(wav.deleteAfterTranscription('/tmp/ghost.wav')).resolves.not.toThrow();
+  });
+
+  it('should_not_delete_wav_if_transcription_failed', async () => {
+    vol.writeFileSync('/tmp/recording.wav', WAV_CONTENT);
+    await wav.handleTranscriptionFailed('/tmp/recording.wav');
+    expect(vol.existsSync('/tmp/recording.wav')).toBe(true);
+  });
+});
+
+describe('WavManager — pruneExpiredRecordings', () => {
+  it('should_delete_wav_files_older_than_24_hours', async () => {
+    const now = Date.now();
+    const vol = new Volume();
+    vol.mkdirSync('/tmp', { recursive: true });
+    vol.writeFileSync('/tmp/old.wav', WAV_CONTENT);
+    // Parchear stat para simular archivo de 25h de antigüedad
+    const origStat = vol.statSync.bind(vol);
+    vol.statSync = (p: unknown) => {
+      const s = origStat(p as string);
+      (s as Record<string, unknown>).mtimeMs = now - 25 * 3_600_000;
+      return s;
+    };
+
+    const time = new MockTimeProvider(now);
+    const wav = new WavManager({ fs: vol as never, time });
+    await wav.pruneExpiredRecordings('/tmp');
+    expect(vol.existsSync('/tmp/old.wav')).toBe(false);
+  });
+
+  it('should_keep_wav_files_newer_than_24_hours', async () => {
+    const now = Date.now();
+    const vol = new Volume();
+    vol.mkdirSync('/tmp', { recursive: true });
+    vol.writeFileSync('/tmp/fresh.wav', WAV_CONTENT);
+    const origStat = vol.statSync.bind(vol);
+    vol.statSync = (p: unknown) => {
+      const s = origStat(p as string);
+      (s as Record<string, unknown>).mtimeMs = now - 1 * 3_600_000; // 1h
+      return s;
+    };
+
+    const time = new MockTimeProvider(now);
+    const wav = new WavManager({ fs: vol as never, time });
+    await wav.pruneExpiredRecordings('/tmp');
+    expect(vol.existsSync('/tmp/fresh.wav')).toBe(true);
+  });
+
+  it('should_only_prune_wav_files_not_other_extensions', async () => {
+    const now = Date.now();
+    const vol = new Volume();
+    vol.mkdirSync('/tmp', { recursive: true });
+    vol.writeFileSync('/tmp/old.wav', WAV_CONTENT);
+    vol.writeFileSync('/tmp/notes.txt', 'keep me');
+    const origStat = vol.statSync.bind(vol);
+    vol.statSync = (p: unknown) => {
+      const s = origStat(p as string);
+      (s as Record<string, unknown>).mtimeMs = now - 25 * 3_600_000;
+      return s;
+    };
+
+    const time = new MockTimeProvider(now);
+    const wav = new WavManager({ fs: vol as never, time });
+    await wav.pruneExpiredRecordings('/tmp');
+    expect(vol.existsSync('/tmp/old.wav')).toBe(false);
+    expect(vol.existsSync('/tmp/notes.txt')).toBe(true);
+  });
+});

--- a/src/cortex/wav/WavManager.ts
+++ b/src/cortex/wav/WavManager.ts
@@ -1,0 +1,69 @@
+import type { IFs } from 'memfs';
+import type { TimeProvider } from '../__mocks__/MockTimeProvider';
+
+const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 horas
+
+interface WavManagerOptions {
+  fs: IFs;
+  time: TimeProvider;
+}
+
+/**
+ * Gestiona archivos .wav temporales de grabación.
+ *
+ * Privacidad (REQ-22):
+ * - Elimina el .wav inmediatamente tras una transcripción exitosa.
+ * - NO elimina si la transcripción falló (permite re-intentos).
+ * - Poda automática de .wav con más de 24h de antigüedad.
+ */
+export class WavManager {
+  private readonly fs: IFs;
+  private readonly time: TimeProvider;
+
+  constructor({ fs, time }: WavManagerOptions) {
+    this.fs = fs;
+    this.time = time;
+  }
+
+  /** Elimina el archivo .wav tras una transcripción exitosa. */
+  async deleteAfterTranscription(path: string): Promise<void> {
+    try {
+      this.fs.unlinkSync(path);
+    } catch {
+      // Archivo inexistente — no es error
+    }
+  }
+
+  /**
+   * Registra que la transcripción falló.
+   * El archivo debe conservarse para re-intentos manuales.
+   * (No hace nada sobre el archivo — intencional.)
+   */
+  async handleTranscriptionFailed(_path: string): Promise<void> {
+    // Comportamiento explícito: conservar el archivo
+  }
+
+  /**
+   * Elimina todos los archivos .wav en `dir` con más de 24h de antigüedad.
+   * Solo actúa sobre archivos con extensión .wav.
+   */
+  async pruneExpiredRecordings(dir: string): Promise<void> {
+    const now = this.time.now();
+    const entries = this.fs.readdirSync(dir) as string[];
+
+    for (const entry of entries) {
+      if (!entry.endsWith('.wav')) continue;
+
+      const fullPath = `${dir}/${entry}`;
+      try {
+        const stat = this.fs.statSync(fullPath);
+        const age = now - (stat.mtimeMs as number);
+        if (age > MAX_AGE_MS) {
+          this.fs.unlinkSync(fullPath);
+        }
+      } catch {
+        // Archivo eliminado por otro proceso entre readdirSync y statSync
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Resumen

- ✅ `WavManager` — privacidad: elimina .wav post-transcripción, poda automática >24h (issues #12, #14)
- ✅ `AetherIndexBridge` — sincroniza documentos de Aether al índice RuVector (issue #10)
- ✅ `SubprocessAdapter` — adaptador IPC genérico con timeout para Docling y Whisper (issues #11, #13)

## Plan de pruebas

- [x] `npx vitest run src/cortex/` → 17/17 verde (solo M2, sin contar M1)
- [x] Sin filesystem real (memfs), sin subprocesos reales, sin Firebase
- [x] Timeout testeado con mock que nunca resuelve (Promise nunca resuelta)

Closes #10, #11, #12, #13, #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)