### PR TITLE
feat(cortex): M3 Memory & Query

### DIFF
--- a/src/cortex/export/IndexExporter.test.ts
+++ b/src/cortex/export/IndexExporter.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { IndexExporter } from './IndexExporter';
+
+function makeStorage() {
+  return {
+    upload: vi.fn().mockResolvedValue({ url: 'https://storage.example/backup.zip' }),
+  };
+}
+
+describe('IndexExporter', () => {
+  let storage: ReturnType<typeof makeStorage>;
+  let exporter: IndexExporter;
+
+  beforeEach(() => {
+    storage = makeStorage();
+    exporter = new IndexExporter({ storage: storage as never });
+  });
+
+  it('should_call_upload_with_correct_path_and_uid', async () => {
+    const result = await exporter.exportToFirebase({ uid: 'user-123', indexPath: '/data/ruvector.db' });
+    expect(storage.upload).toHaveBeenCalledWith(
+      expect.objectContaining({ uid: 'user-123', localPath: '/data/ruvector.db' }),
+    );
+    expect(result.url).toContain('https://');
+  });
+
+  it('should_include_timestamp_in_backup_name', async () => {
+    await exporter.exportToFirebase({ uid: 'user-123', indexPath: '/data/ruvector.db' });
+    const call = storage.upload.mock.calls[0][0] as Record<string, string>;
+    expect(call.remotePath).toMatch(/backup_\d+/);
+  });
+
+  it('should_throw_if_storage_upload_fails', async () => {
+    storage.upload.mockRejectedValueOnce(new Error('quota exceeded'));
+    await expect(
+      exporter.exportToFirebase({ uid: 'user-123', indexPath: '/data/ruvector.db' })
+    ).rejects.toThrow('quota exceeded');
+  });
+});

--- a/src/cortex/export/IndexExporter.ts
+++ b/src/cortex/export/IndexExporter.ts
@@ -1,0 +1,43 @@
+export interface StorageUploadRequest {
+  uid: string;
+  localPath: string;
+  remotePath: string;
+}
+
+export interface StorageUploadResult {
+  url: string;
+}
+
+export interface CloudStorage {
+  upload(req: StorageUploadRequest): Promise<StorageUploadResult>;
+}
+
+interface IndexExporterOptions {
+  storage: CloudStorage;
+}
+
+/**
+ * Exporta el índice RuVector a Firebase Storage bajo la ruta:
+ *   users/{uid}/cortex/backup_{timestamp}.zip
+ *
+ * En producción, CloudStorage es el cliente real de Firebase.
+ * En tests se inyecta un mock para no depender de Firebase real.
+ */
+export class IndexExporter {
+  private readonly storage: CloudStorage;
+
+  constructor({ storage }: IndexExporterOptions) {
+    this.storage = storage;
+  }
+
+  async exportToFirebase(req: { uid: string; indexPath: string }): Promise<StorageUploadResult> {
+    const timestamp = Date.now();
+    const remotePath = `users/${req.uid}/cortex/backup_${timestamp}.zip`;
+
+    return this.storage.upload({
+      uid: req.uid,
+      localPath: req.indexPath,
+      remotePath,
+    });
+  }
+}

--- a/src/cortex/feedback/FeedbackStore.test.ts
+++ b/src/cortex/feedback/FeedbackStore.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { applyPenalty, pruneExpiredFeedback } from './FeedbackStore';
+import { MockTimeProvider } from '../__mocks__/MockTimeProvider';
+
+interface SearchResult { id: string; score: number }
+interface FeedbackEntry { resultId: string; signal: 'positive' | 'negative'; createdAt: number }
+
+describe('FeedbackStore.applyPenalty', () => {
+  it('should_reduce_score_of_negatively_rated_result', () => {
+    const results: SearchResult[] = [{ id: 'doc-1', score: 0.9 }, { id: 'doc-2', score: 0.8 }];
+    const feedback: FeedbackEntry[] = [{ resultId: 'doc-1', signal: 'negative', createdAt: Date.now() }];
+    const penalized = applyPenalty(results, feedback);
+    expect(penalized.find((r) => r.id === 'doc-1')!.score).toBeLessThan(0.9);
+    expect(penalized.find((r) => r.id === 'doc-2')!.score).toBe(0.8);
+  });
+
+  it('should_boost_score_of_positively_rated_result', () => {
+    const results: SearchResult[] = [{ id: 'doc-1', score: 0.7 }];
+    const feedback: FeedbackEntry[] = [{ resultId: 'doc-1', signal: 'positive', createdAt: Date.now() }];
+    const boosted = applyPenalty(results, feedback);
+    expect(boosted.find((r) => r.id === 'doc-1')!.score).toBeGreaterThan(0.7);
+  });
+
+  it('should_not_change_score_of_results_without_feedback', () => {
+    const results: SearchResult[] = [{ id: 'doc-1', score: 0.9 }, { id: 'doc-2', score: 0.8 }];
+    const penalized = applyPenalty(results, []);
+    expect(penalized.find((r) => r.id === 'doc-1')!.score).toBe(0.9);
+    expect(penalized.find((r) => r.id === 'doc-2')!.score).toBe(0.8);
+  });
+
+  it('should_clamp_score_between_0_and_1', () => {
+    const results: SearchResult[] = [{ id: 'doc-1', score: 0.05 }];
+    const feedback: FeedbackEntry[] = [
+      { resultId: 'doc-1', signal: 'negative', createdAt: Date.now() },
+      { resultId: 'doc-1', signal: 'negative', createdAt: Date.now() },
+      { resultId: 'doc-1', signal: 'negative', createdAt: Date.now() },
+    ];
+    const penalized = applyPenalty(results, feedback);
+    expect(penalized[0].score).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should_clamp_score_to_max_1_after_boost', () => {
+    const results: SearchResult[] = [{ id: 'doc-1', score: 0.99 }];
+    const feedback: FeedbackEntry[] = [{ resultId: 'doc-1', signal: 'positive', createdAt: Date.now() }];
+    const boosted = applyPenalty(results, feedback);
+    expect(boosted[0].score).toBeLessThanOrEqual(1);
+  });
+
+  it('should_apply_multiple_feedback_signals_cumulatively', () => {
+    const results: SearchResult[] = [{ id: 'doc-1', score: 0.9 }];
+    const feedback: FeedbackEntry[] = [
+      { resultId: 'doc-1', signal: 'negative', createdAt: Date.now() },
+      { resultId: 'doc-1', signal: 'negative', createdAt: Date.now() },
+    ];
+    const single: FeedbackEntry[] = [{ resultId: 'doc-1', signal: 'negative', createdAt: Date.now() }];
+    const double = applyPenalty(results, feedback);
+    const once = applyPenalty(results, single);
+    expect(double[0].score).toBeLessThan(once[0].score);
+  });
+});
+
+describe('FeedbackStore.pruneExpiredFeedback', () => {
+  it('should_prune_feedback_older_than_retention_days', () => {
+    const now = Date.now();
+    const time = new MockTimeProvider(now);
+    const old: FeedbackEntry[] = [
+      { resultId: 'x', signal: 'negative', createdAt: now - 91 * 86_400_000 },
+    ];
+    const pruned = pruneExpiredFeedback(old, { retentionDays: 90, time });
+    expect(pruned).toHaveLength(0);
+  });
+
+  it('should_keep_feedback_within_retention_window', () => {
+    const now = Date.now();
+    const time = new MockTimeProvider(now);
+    const recent: FeedbackEntry[] = [
+      { resultId: 'x', signal: 'positive', createdAt: now - 30 * 86_400_000 },
+    ];
+    const pruned = pruneExpiredFeedback(recent, { retentionDays: 90, time });
+    expect(pruned).toHaveLength(1);
+  });
+
+  it('should_handle_empty_feedback_list', () => {
+    const time = new MockTimeProvider(Date.now());
+    expect(pruneExpiredFeedback([], { retentionDays: 90, time })).toHaveLength(0);
+  });
+
+  it('should_keep_feedback_exactly_at_boundary', () => {
+    const now = Date.now();
+    const time = new MockTimeProvider(now);
+    const boundary: FeedbackEntry[] = [
+      { resultId: 'x', signal: 'negative', createdAt: now - 90 * 86_400_000 },
+    ];
+    // exactamente 90 días → debe conservarse (no expirado todavía)
+    const pruned = pruneExpiredFeedback(boundary, { retentionDays: 90, time });
+    expect(pruned).toHaveLength(1);
+  });
+});

--- a/src/cortex/feedback/FeedbackStore.ts
+++ b/src/cortex/feedback/FeedbackStore.ts
@@ -1,0 +1,53 @@
+import type { TimeProvider } from '../__mocks__/MockTimeProvider';
+
+const PENALTY_DELTA = 0.15;
+const BOOST_DELTA = 0.10;
+
+export interface SearchResult {
+  id: string;
+  score: number;
+}
+
+export interface FeedbackEntry {
+  resultId: string;
+  signal: 'positive' | 'negative';
+  createdAt: number;
+}
+
+export interface PruneOptions {
+  retentionDays: number;
+  time: TimeProvider;
+}
+
+/**
+ * Ajusta los scores de resultados de búsqueda según el historial de feedback.
+ *
+ * - Señal negativa: resta PENALTY_DELTA por ocurrencia.
+ * - Señal positiva: suma BOOST_DELTA por ocurrencia.
+ * - Score final clampeado a [0, 1].
+ *
+ * Las señales se aplican de forma acumulativa para que feedback
+ * repetido tenga más peso que feedback puntual.
+ */
+export function applyPenalty(results: SearchResult[], feedback: FeedbackEntry[]): SearchResult[] {
+  return results.map((result) => {
+    const signals = feedback.filter((f) => f.resultId === result.id);
+    let score = result.score;
+
+    for (const entry of signals) {
+      if (entry.signal === 'negative') score -= PENALTY_DELTA;
+      else if (entry.signal === 'positive') score += BOOST_DELTA;
+    }
+
+    return { ...result, score: Math.min(1, Math.max(0, score)) };
+  });
+}
+
+/**
+ * Elimina entradas de feedback más antiguas que retentionDays.
+ * Las entradas exactamente en el límite se conservan.
+ */
+export function pruneExpiredFeedback(feedback: FeedbackEntry[], opts: PruneOptions): FeedbackEntry[] {
+  const cutoff = opts.time.now() - opts.retentionDays * 86_400_000;
+  return feedback.filter((entry) => entry.createdAt >= cutoff);
+}

--- a/src/cortex/grounding/GroundingValidator.test.ts
+++ b/src/cortex/grounding/GroundingValidator.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { isGrounded, buildGroundedResponse } from './GroundingValidator';
+import type { RuVectorChunk } from '../ruvector/RuVectorAdapter';
+
+function chunk(content: string, docId = 'doc-1', title = 'Apuntes'): RuVectorChunk {
+  return { chunkId: `c-${Math.random()}`, score: 0.9, content, docId };
+}
+
+// ─── isGrounded ────────────────────────────────────────────────────────────
+
+describe('GroundingValidator.isGrounded — REQ-22', () => {
+  it('should_return_true_when_response_uses_indexed_content', () => {
+    const chunks = [chunk('El three-way handshake tiene 3 pasos: SYN, SYN-ACK, ACK.')];
+    const response = 'Según tus apuntes, el three-way handshake tiene 3 pasos: SYN, SYN-ACK y ACK.';
+    expect(isGrounded(response, chunks)).toBe(true);
+  });
+
+  it('should_return_false_when_chunks_are_empty', () => {
+    expect(isGrounded('cualquier respuesta', [])).toBe(false);
+  });
+
+  it('should_return_false_when_response_has_no_overlap_with_chunks', () => {
+    const chunks = [chunk('El three-way handshake...')];
+    const response = 'La fotosíntesis es un proceso biológico que ocurre en los cloroplastos.';
+    expect(isGrounded(response, chunks)).toBe(false);
+  });
+
+  it('should_be_case_insensitive_when_checking_overlap', () => {
+    const chunks = [chunk('PROTOCOLO TCP requiere handshake')];
+    const response = 'según tus apuntes, el protocolo tcp requiere handshake';
+    expect(isGrounded(response, chunks)).toBe(true);
+  });
+
+  it('should_handle_empty_response_string', () => {
+    const chunks = [chunk('contenido')];
+    expect(isGrounded('', chunks)).toBe(false);
+  });
+
+  it('should_handle_single_word_overlap', () => {
+    // Una sola palabra en común no es suficiente grounding
+    const chunks = [chunk('photosynthesis is a complex biological process')];
+    const response = 'process';
+    expect(isGrounded(response, chunks)).toBe(false);
+  });
+});
+
+// ─── buildGroundedResponse ─────────────────────────────────────────────────
+
+describe('GroundingValidator.buildGroundedResponse — REQ-22', () => {
+  it('should_return_no_results_message_when_chunks_empty', () => {
+    const result = buildGroundedResponse([], 'qué es TCP');
+    expect(result.content).toBe('No encontré información sobre esto en tu índice.');
+    expect(result.sources).toHaveLength(0);
+    expect(result.grounded).toBe(false);
+  });
+
+  it('should_include_source_citation_for_every_chunk', () => {
+    const chunks = [
+      chunk('TCP es un protocolo orientado a conexión.', 'doc-1'),
+      chunk('UDP no garantiza entrega.', 'doc-2'),
+    ];
+    const result = buildGroundedResponse(chunks, 'diferencia TCP y UDP');
+    expect(result.sources).toHaveLength(2);
+    expect(result.sources.map((s) => s.docId)).toContain('doc-1');
+    expect(result.sources.map((s) => s.docId)).toContain('doc-2');
+  });
+
+  it('should_mark_response_as_grounded_when_chunks_present', () => {
+    const chunks = [chunk('contenido relevante')];
+    const result = buildGroundedResponse(chunks, 'query');
+    expect(result.grounded).toBe(true);
+  });
+
+  it('should_include_chunk_content_in_response', () => {
+    const chunks = [chunk('El modelo OSI tiene 7 capas.')];
+    const result = buildGroundedResponse(chunks, 'capas OSI');
+    expect(result.content).toContain('El modelo OSI tiene 7 capas.');
+  });
+
+  it('should_not_include_content_outside_provided_chunks', () => {
+    const chunks = [chunk('Solo esto está indexado.')];
+    const result = buildGroundedResponse(chunks, 'query');
+    // El contenido de la respuesta debe ser construido SOLO desde los chunks
+    expect(result.content).not.toContain('conocimiento externo');
+  });
+
+  it('should_deduplicate_sources_by_docId', () => {
+    const chunks = [
+      chunk('Fragmento 1 del documento A', 'doc-A'),
+      chunk('Fragmento 2 del documento A', 'doc-A'),
+    ];
+    const result = buildGroundedResponse(chunks, 'query');
+    const docIds = result.sources.map((s) => s.docId);
+    expect(new Set(docIds).size).toBe(docIds.length); // sin duplicados
+  });
+});

--- a/src/cortex/grounding/GroundingValidator.ts
+++ b/src/cortex/grounding/GroundingValidator.ts
@@ -1,0 +1,88 @@
+import type { RuVectorChunk } from '../ruvector/RuVectorAdapter';
+
+/** Mínimo de palabras significativas en común para considerar grounded */
+const MIN_OVERLAP_WORDS = 2;
+
+/** Palabras vacías que no cuentan como evidencia de grounding */
+const STOP_WORDS = new Set([
+  'el', 'la', 'los', 'las', 'un', 'una', 'de', 'en', 'y', 'a', 'que', 'es',
+  'se', 'no', 'con', 'por', 'su', 'para', 'al', 'del', 'como', 'o', 'más',
+  'the', 'a', 'an', 'is', 'are', 'of', 'in', 'and', 'to', 'it', 'for',
+]);
+
+export interface GroundedSource {
+  docId: string;
+  chunkId: string;
+}
+
+export interface GroundedResponse {
+  content: string;
+  sources: GroundedSource[];
+  grounded: boolean;
+}
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/\W+/)
+      .filter((w) => w.length > 2 && !STOP_WORDS.has(w)),
+  );
+}
+
+/**
+ * Verifica si una respuesta está fundamentada en los chunks del índice local.
+ *
+ * REQ-22: Cortex NUNCA debe responder con conocimiento externo.
+ * Una respuesta se considera grounded si comparte al menos MIN_OVERLAP_WORDS
+ * palabras significativas con alguno de los chunks recuperados.
+ */
+export function isGrounded(response: string, chunks: RuVectorChunk[]): boolean {
+  if (!response || chunks.length === 0) return false;
+
+  const responseTokens = tokenize(response);
+  if (responseTokens.size === 0) return false;
+
+  for (const chunk of chunks) {
+    const chunkTokens = tokenize(chunk.content);
+    let overlap = 0;
+    for (const token of responseTokens) {
+      if (chunkTokens.has(token)) overlap++;
+      if (overlap >= MIN_OVERLAP_WORDS) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Construye una respuesta grounded a partir de los chunks recuperados.
+ *
+ * Si no hay chunks → respuesta estándar de "no encontré información".
+ * Las fuentes se deduplicanan por docId para evitar citas duplicadas.
+ */
+export function buildGroundedResponse(chunks: RuVectorChunk[], _query: string): GroundedResponse {
+  if (chunks.length === 0) {
+    return {
+      content: 'No encontré información sobre esto en tu índice.',
+      sources: [],
+      grounded: false,
+    };
+  }
+
+  // Construir contenido concatenando los chunks por orden de score
+  const sorted = [...chunks].sort((a, b) => b.score - a.score);
+  const content = sorted.map((c) => c.content).join('\n\n');
+
+  // Deduplicar fuentes por docId
+  const seen = new Set<string>();
+  const sources: GroundedSource[] = [];
+  for (const chunk of sorted) {
+    if (!seen.has(chunk.docId)) {
+      seen.add(chunk.docId);
+      sources.push({ docId: chunk.docId, chunkId: chunk.chunkId });
+    }
+  }
+
+  return { content, sources, grounded: true };
+}

--- a/src/cortex/ruvector/RuVectorAdapter.test.ts
+++ b/src/cortex/ruvector/RuVectorAdapter.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RuVectorAdapter } from './RuVectorAdapter';
+
+function makeMockSubprocess() {
+  return {
+    request: vi.fn(),
+  };
+}
+
+describe('RuVectorAdapter — indexDocument', () => {
+  let sub: ReturnType<typeof makeMockSubprocess>;
+  let rv: RuVectorAdapter;
+
+  beforeEach(() => {
+    sub = makeMockSubprocess();
+    rv = new RuVectorAdapter({ subprocess: sub as never });
+  });
+
+  it('should_index_document_and_return_chunk_count', async () => {
+    sub.request.mockResolvedValueOnce({ id: 'r1', status: 'ok', data: { chunks: 8 } });
+    const result = await rv.indexDocument({ docId: 'doc-1', path: '/notes/tcp.md', mimeType: 'text/markdown' });
+    expect(result.chunks).toBe(8);
+    expect(sub.request).toHaveBeenCalledWith(expect.objectContaining({ action: 'index_document' }), undefined);
+  });
+
+  it('should_throw_if_subprocess_returns_error', async () => {
+    sub.request.mockRejectedValueOnce(new Error('disk full'));
+    await expect(rv.indexDocument({ docId: 'doc-1', path: '/notes/tcp.md', mimeType: 'text/markdown' }))
+      .rejects.toThrow('disk full');
+  });
+});
+
+describe('RuVectorAdapter — query', () => {
+  let sub: ReturnType<typeof makeMockSubprocess>;
+  let rv: RuVectorAdapter;
+
+  beforeEach(() => {
+    sub = makeMockSubprocess();
+    rv = new RuVectorAdapter({ subprocess: sub as never });
+  });
+
+  it('should_return_ranked_chunks_for_query', async () => {
+    sub.request.mockResolvedValueOnce({
+      id: 'r2', status: 'ok',
+      data: {
+        results: [
+          { chunkId: 'c1', score: 0.95, content: 'El three-way handshake...', docId: 'doc-1' },
+          { chunkId: 'c2', score: 0.80, content: 'SYN-ACK es el segundo paso...', docId: 'doc-1' },
+        ],
+      },
+    });
+    const result = await rv.query({ text: 'qué es el three-way handshake', topK: 2 });
+    expect(result).toHaveLength(2);
+    expect(result[0].score).toBeGreaterThan(result[1].score);
+  });
+
+  it('should_return_empty_array_when_index_is_empty', async () => {
+    sub.request.mockResolvedValueOnce({ id: 'r3', status: 'ok', data: { results: [] } });
+    const result = await rv.query({ text: 'anything', topK: 5 });
+    expect(result).toHaveLength(0);
+  });
+
+  it('should_pass_topK_to_subprocess', async () => {
+    sub.request.mockResolvedValueOnce({ id: 'r4', status: 'ok', data: { results: [] } });
+    await rv.query({ text: 'query', topK: 10 });
+    expect(sub.request).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: expect.objectContaining({ topK: 10 }) }),
+      undefined,
+    );
+  });
+});
+
+describe('RuVectorAdapter — deleteDocument', () => {
+  it('should_delete_document_from_index', async () => {
+    const sub = makeMockSubprocess();
+    sub.request.mockResolvedValueOnce({ id: 'r5', status: 'ok', data: {} });
+    const rv = new RuVectorAdapter({ subprocess: sub as never });
+    await expect(rv.deleteDocument({ docId: 'doc-1' })).resolves.not.toThrow();
+    expect(sub.request).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'delete_document', payload: { docId: 'doc-1' } }),
+      undefined,
+    );
+  });
+
+  it('should_handle_not_found_gracefully', async () => {
+    const sub = makeMockSubprocess();
+    sub.request.mockResolvedValueOnce({ id: 'r6', status: 'ok', data: { notFound: true } });
+    const rv = new RuVectorAdapter({ subprocess: sub as never });
+    await expect(rv.deleteDocument({ docId: 'ghost' })).resolves.not.toThrow();
+  });
+});

--- a/src/cortex/ruvector/RuVectorAdapter.ts
+++ b/src/cortex/ruvector/RuVectorAdapter.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from 'node:crypto';
+import type { SubprocessAdapter, RequestOptions } from '../subprocess/SubprocessAdapter';
+
+export interface RuVectorChunk {
+  chunkId: string;
+  score: number;
+  content: string;
+  docId: string;
+}
+
+export interface IndexDocumentRequest {
+  docId: string;
+  path: string;
+  mimeType: string;
+}
+
+export interface QueryRequest {
+  text: string;
+  topK: number;
+}
+
+interface RuVectorAdapterOptions {
+  subprocess: SubprocessAdapter;
+}
+
+/**
+ * Adaptador de alto nivel para el binario RuVector (Rust).
+ *
+ * Traduce operaciones semánticas (index, query, delete) a llamadas
+ * IPC via SubprocessAdapter, aislando al resto del sistema del
+ * protocolo de bajo nivel.
+ */
+export class RuVectorAdapter {
+  private readonly subprocess: SubprocessAdapter;
+
+  constructor({ subprocess }: RuVectorAdapterOptions) {
+    this.subprocess = subprocess;
+  }
+
+  async indexDocument(req: IndexDocumentRequest, opts?: RequestOptions): Promise<{ chunks: number }> {
+    const response = await this.subprocess.request(
+      { id: randomUUID(), action: 'index_document', payload: { ...req } },
+      opts,
+    );
+    return { chunks: (response.data as Record<string, number>).chunks };
+  }
+
+  async query(req: QueryRequest, opts?: RequestOptions): Promise<RuVectorChunk[]> {
+    const response = await this.subprocess.request(
+      { id: randomUUID(), action: 'query', payload: { ...req } },
+      opts,
+    );
+    return ((response.data as Record<string, unknown>).results ?? []) as RuVectorChunk[];
+  }
+
+  async deleteDocument(req: { docId: string }, opts?: RequestOptions): Promise<void> {
+    await this.subprocess.request(
+      { id: randomUUID(), action: 'delete_document', payload: { docId: req.docId } },
+      opts,
+    );
+  }
+}


### PR DESCRIPTION
## Resumen

- ✅ `RuVectorAdapter` — index / query / delete sobre el binario RuVector (issue #15)
- ✅ `GroundingValidator` — REQ-22: `isGrounded()` + `buildGroundedResponse()` con deduplicación de fuentes (issues #16, #19)
- ✅ `FeedbackStore` — `applyPenalty()` acumulativo con clamp, `pruneExpiredFeedback()` con límite exacto (issue #17)
- ✅ `IndexExporter` — export del índice a Firebase Storage via CloudStorage port (issue #18)

## Plan de pruebas

- [x] `npx vitest run src/cortex/` → **83/83 verde** (M1 + M2 + M3 acumulados)
- [x] GroundingValidator: case-insensitive, stop-words filtradas, umbral mínimo de overlap
- [x] FeedbackStore: clamp [0,1], señales acumulativas, boundary exacto en pruneExpired
- [x] Sin Firebase real, sin RuVector real, sin subprocesos reales

Closes #15, #16, #17, #18, #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)