### PR TITLE
feat(cortex): M4 UI — Activity, FloatingPanel, Tab, NexusContext

### DIFF
--- a/src/cortex/ui/CortexActivityIndicator.test.tsx
+++ b/src/cortex/ui/CortexActivityIndicator.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, it, expect } from 'vitest';
+import { CortexActivityIndicator } from './CortexActivityIndicator';
+import { useCortexStore } from './cortexStore';
+
+beforeEach(() => useCortexStore.getState().reset());
+
+describe('CortexActivityIndicator', () => {
+  it('should_show_idle_state_by_default', () => {
+    render(<CortexActivityIndicator />);
+    expect(screen.getByTestId('cortex-activity')).toHaveTextContent(/inactivo|idle/i);
+  });
+
+  it('should_show_indexing_with_document_title', () => {
+    useCortexStore.getState().setActivity({ type: 'indexing', docTitle: 'Apuntes TCP' });
+    render(<CortexActivityIndicator />);
+    expect(screen.getByTestId('cortex-activity')).toHaveTextContent(/indexando/i);
+    expect(screen.getByTestId('cortex-activity')).toHaveTextContent('Apuntes TCP');
+  });
+
+  it('should_show_progress_when_indexing', () => {
+    useCortexStore.getState().setActivity({ type: 'indexing', docTitle: 'Redes', progress: 60 });
+    render(<CortexActivityIndicator />);
+    expect(screen.getByTestId('cortex-progress')).toHaveTextContent('60');
+  });
+
+  it('should_not_show_progress_bar_when_no_progress_value', () => {
+    useCortexStore.getState().setActivity({ type: 'indexing', docTitle: 'Redes' });
+    render(<CortexActivityIndicator />);
+    expect(screen.queryByTestId('cortex-progress')).not.toBeInTheDocument();
+  });
+
+  it('should_show_transcribing_with_filename', () => {
+    useCortexStore.getState().setActivity({ type: 'transcribing', filename: 'clase-01.wav' });
+    render(<CortexActivityIndicator />);
+    expect(screen.getByTestId('cortex-activity')).toHaveTextContent(/transcribiendo/i);
+    expect(screen.getByTestId('cortex-activity')).toHaveTextContent('clase-01.wav');
+  });
+
+  it('should_show_querying_state', () => {
+    useCortexStore.getState().setActivity({ type: 'querying', query: 'TCP handshake' });
+    render(<CortexActivityIndicator />);
+    expect(screen.getByTestId('cortex-activity')).toHaveTextContent(/consultando/i);
+  });
+
+  it('should_show_ocr_state_with_filename', () => {
+    useCortexStore.getState().setActivity({ type: 'ocr', filename: 'parcial.pdf' });
+    render(<CortexActivityIndicator />);
+    expect(screen.getByTestId('cortex-activity')).toHaveTextContent(/ocr/i);
+    expect(screen.getByTestId('cortex-activity')).toHaveTextContent('parcial.pdf');
+  });
+});

--- a/src/cortex/ui/CortexActivityIndicator.tsx
+++ b/src/cortex/ui/CortexActivityIndicator.tsx
@@ -1,0 +1,38 @@
+import { useCortexStore, type CortexActivity } from './cortexStore';
+
+function activityLabel(activity: CortexActivity): string {
+  switch (activity.type) {
+    case 'idle':
+      return 'Inactivo';
+    case 'indexing':
+      return `Indexando: ${activity.docTitle}`;
+    case 'transcribing':
+      return `Transcribiendo: ${activity.filename}`;
+    case 'querying':
+      return `Consultando: ${activity.query}`;
+    case 'ocr':
+      return `OCR: ${activity.filename}`;
+  }
+}
+
+/**
+ * Indicador compacto del estado actual de Cortex.
+ * Pensado para vivir en la barra lateral o header de la app.
+ */
+export function CortexActivityIndicator() {
+  const activity = useCortexStore((s) => s.activity);
+  const progress = activity.type === 'indexing' ? activity.progress : undefined;
+
+  return (
+    <div className="cortex-activity-indicator">
+      <span data-testid="cortex-activity" className="cortex-activity-label">
+        {activityLabel(activity)}
+      </span>
+      {progress !== undefined && (
+        <span data-testid="cortex-progress" className="cortex-activity-progress">
+          {progress}%
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/cortex/ui/CortexFloatingPanel.test.tsx
+++ b/src/cortex/ui/CortexFloatingPanel.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { CortexFloatingPanel } from './CortexFloatingPanel';
+import { useCortexStore } from './cortexStore';
+
+beforeEach(() => {
+  useCortexStore.getState().reset();
+  mockOnQuery.mockClear();
+});
+
+const mockOnQuery = vi.fn();
+
+describe('CortexFloatingPanel — renderizado', () => {
+  it('should_render_query_input', () => {
+    render(<CortexFloatingPanel onQuery={mockOnQuery} />);
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('should_render_submit_button', () => {
+    render(<CortexFloatingPanel onQuery={mockOnQuery} />);
+    expect(screen.getByRole('button', { name: /buscar|consultar|search/i })).toBeInTheDocument();
+  });
+
+  it('should_show_empty_state_when_no_results', () => {
+    render(<CortexFloatingPanel onQuery={mockOnQuery} />);
+    expect(screen.getByTestId('cortex-empty')).toBeInTheDocument();
+  });
+});
+
+describe('CortexFloatingPanel — interacción', () => {
+  it('should_call_onQuery_with_input_value_on_submit', async () => {
+    render(<CortexFloatingPanel onQuery={mockOnQuery} />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'qué es TCP' } });
+    fireEvent.click(screen.getByRole('button', { name: /buscar|consultar|search/i }));
+    expect(mockOnQuery).toHaveBeenCalledWith('qué es TCP');
+  });
+
+  it('should_not_call_onQuery_with_empty_input', () => {
+    render(<CortexFloatingPanel onQuery={mockOnQuery} />);
+    fireEvent.click(screen.getByRole('button', { name: /buscar|consultar|search/i }));
+    expect(mockOnQuery).not.toHaveBeenCalled();
+  });
+
+  it('should_show_loading_spinner_while_querying', () => {
+    useCortexStore.getState().setIsQuerying(true);
+    render(<CortexFloatingPanel onQuery={mockOnQuery} />);
+    expect(screen.getByTestId('cortex-loading')).toBeInTheDocument();
+  });
+
+  it('should_render_results_from_store', () => {
+    useCortexStore.getState().setQueryResults([
+      { chunkId: 'c1', docId: 'doc-1', content: 'El three-way handshake...', score: 0.95 },
+      { chunkId: 'c2', docId: 'doc-1', content: 'SYN-ACK es el segundo paso...', score: 0.80 },
+    ]);
+    render(<CortexFloatingPanel onQuery={mockOnQuery} />);
+    expect(screen.getByText(/three-way handshake/i)).toBeInTheDocument();
+    expect(screen.getByText(/SYN-ACK/i)).toBeInTheDocument();
+  });
+
+  it('should_show_error_message_when_query_fails', () => {
+    useCortexStore.getState().setQueryError('RuVector no disponible');
+    render(<CortexFloatingPanel onQuery={mockOnQuery} />);
+    expect(screen.getByTestId('cortex-error')).toHaveTextContent('RuVector no disponible');
+  });
+
+  it('should_submit_on_enter_key', () => {
+    render(<CortexFloatingPanel onQuery={mockOnQuery} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'modelo OSI' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mockOnQuery).toHaveBeenCalledWith('modelo OSI');
+  });
+});

--- a/src/cortex/ui/CortexFloatingPanel.tsx
+++ b/src/cortex/ui/CortexFloatingPanel.tsx
@@ -1,0 +1,83 @@
+import { useState, type KeyboardEvent } from 'react';
+import { useCortexStore, type CortexQueryResult } from './cortexStore';
+
+interface CortexFloatingPanelProps {
+  onQuery: (query: string) => void;
+}
+
+function ResultItem({ result }: { result: CortexQueryResult }) {
+  return (
+    <li className="cortex-result-item">
+      <p className="cortex-result-content">{result.content}</p>
+      <span className="cortex-result-score">{(result.score * 100).toFixed(0)}%</span>
+    </li>
+  );
+}
+
+/**
+ * Panel flotante de consulta rápida al índice RuVector.
+ *
+ * Gestiona el input del usuario y delega la lógica de búsqueda
+ * al callback onQuery (inyectado desde la página padre).
+ * El estado de resultados, loading y error vive en cortexStore.
+ */
+export function CortexFloatingPanel({ onQuery }: CortexFloatingPanelProps) {
+  const [input, setInput] = useState('');
+  const results = useCortexStore((s) => s.queryResults);
+  const isQuerying = useCortexStore((s) => s.isQuerying);
+  const queryError = useCortexStore((s) => s.queryError);
+
+  const handleSubmit = () => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    onQuery(trimmed);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') handleSubmit();
+  };
+
+  return (
+    <div className="cortex-floating-panel">
+      <div className="cortex-search-row">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Consultar índice..."
+          className="cortex-search-input"
+        />
+        <button type="button" onClick={handleSubmit} className="cortex-search-btn">
+          Buscar
+        </button>
+      </div>
+
+      {isQuerying && (
+        <div data-testid="cortex-loading" className="cortex-loading">
+          Consultando…
+        </div>
+      )}
+
+      {queryError && (
+        <div data-testid="cortex-error" className="cortex-error">
+          {queryError}
+        </div>
+      )}
+
+      {!isQuerying && !queryError && results.length === 0 && (
+        <div data-testid="cortex-empty" className="cortex-empty">
+          Sin resultados
+        </div>
+      )}
+
+      {results.length > 0 && (
+        <ul className="cortex-results-list">
+          {results.map((r) => (
+            <ResultItem key={r.chunkId} result={r} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/cortex/ui/CortexTab.test.tsx
+++ b/src/cortex/ui/CortexTab.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, it, expect } from 'vitest';
+import { CortexTab } from './CortexTab';
+import { useCortexStore } from './cortexStore';
+
+beforeEach(() => useCortexStore.getState().reset());
+
+describe('CortexTab — estado del índice', () => {
+  it('should_show_indexed_doc_count', () => {
+    useCortexStore.getState().setIndexedDocCount(42);
+    render(<CortexTab />);
+    expect(screen.getByTestId('cortex-doc-count')).toHaveTextContent('42');
+  });
+
+  it('should_show_zero_docs_when_index_empty', () => {
+    render(<CortexTab />);
+    expect(screen.getByTestId('cortex-doc-count')).toHaveTextContent('0');
+  });
+
+  it('should_show_last_indexed_timestamp_when_set', () => {
+    const ts = new Date('2026-03-22T10:00:00Z').getTime();
+    useCortexStore.getState().setLastIndexedAt(ts);
+    render(<CortexTab />);
+    expect(screen.getByTestId('cortex-last-indexed')).toBeInTheDocument();
+    // Debe mostrar algún formato de fecha/hora legible
+    expect(screen.getByTestId('cortex-last-indexed').textContent).not.toBe('');
+  });
+
+  it('should_show_never_when_never_indexed', () => {
+    render(<CortexTab />);
+    expect(screen.getByTestId('cortex-last-indexed')).toHaveTextContent(/nunca|never/i);
+  });
+});
+
+describe('CortexTab — actividad', () => {
+  it('should_show_current_activity', () => {
+    useCortexStore.getState().setActivity({ type: 'indexing', docTitle: 'Parcial 2' });
+    render(<CortexTab />);
+    expect(screen.getByTestId('cortex-activity')).toHaveTextContent(/indexando/i);
+    expect(screen.getByTestId('cortex-activity')).toHaveTextContent('Parcial 2');
+  });
+
+  it('should_show_idle_when_no_activity', () => {
+    render(<CortexTab />);
+    expect(screen.getByTestId('cortex-activity')).toHaveTextContent(/inactivo|idle/i);
+  });
+});
+
+describe('CortexTab — estructura', () => {
+  it('should_render_section_headings', () => {
+    render(<CortexTab />);
+    expect(screen.getByText(/estado del índice/i)).toBeInTheDocument();
+    expect(screen.getByText(/actividad/i)).toBeInTheDocument();
+  });
+});

--- a/src/cortex/ui/CortexTab.tsx
+++ b/src/cortex/ui/CortexTab.tsx
@@ -1,0 +1,49 @@
+import { useCortexStore, type CortexActivity } from './cortexStore';
+
+function activityLabel(activity: CortexActivity): string {
+  switch (activity.type) {
+    case 'idle': return 'Inactivo';
+    case 'indexing': return `Indexando: ${activity.docTitle}`;
+    case 'transcribing': return `Transcribiendo: ${activity.filename}`;
+    case 'querying': return `Consultando: ${activity.query}`;
+    case 'ocr': return `OCR: ${activity.filename}`;
+  }
+}
+
+function formatTs(ts: number | null): string {
+  if (ts === null) return 'Nunca';
+  return new Date(ts).toLocaleString('es-AR', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  });
+}
+
+/**
+ * Tab dedicado de Cortex: muestra estado del índice, actividad actual
+ * y provee acciones de configuración manual.
+ */
+export function CortexTab() {
+  const indexedDocCount = useCortexStore((s) => s.indexedDocCount);
+  const lastIndexedAt = useCortexStore((s) => s.lastIndexedAt);
+  const activity = useCortexStore((s) => s.activity);
+
+  return (
+    <div className="cortex-tab">
+      <section className="cortex-section">
+        <h2 className="cortex-section-title">Estado del índice</h2>
+        <dl className="cortex-stats">
+          <dt>Documentos indexados</dt>
+          <dd data-testid="cortex-doc-count">{indexedDocCount}</dd>
+
+          <dt>Última indexación</dt>
+          <dd data-testid="cortex-last-indexed">{formatTs(lastIndexedAt)}</dd>
+        </dl>
+      </section>
+
+      <section className="cortex-section">
+        <h2 className="cortex-section-title">Actividad</h2>
+        <span data-testid="cortex-activity">{activityLabel(activity)}</span>
+      </section>
+    </div>
+  );
+}

--- a/src/cortex/ui/NexusContextSurface.test.tsx
+++ b/src/cortex/ui/NexusContextSurface.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, it, expect } from 'vitest';
+import { NexusContextSurface } from './NexusContextSurface';
+import { useCortexStore } from './cortexStore';
+
+beforeEach(() => useCortexStore.getState().reset());
+
+describe('NexusContextSurface', () => {
+  it('should_render_nothing_when_no_results_and_not_loading', () => {
+    const { container } = render(<NexusContextSurface taskTitle="Estudiar TCP" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should_show_loading_state', () => {
+    useCortexStore.getState().setIsQuerying(true);
+    render(<NexusContextSurface taskTitle="Estudiar TCP" />);
+    expect(screen.getByTestId('nexus-context-loading')).toBeInTheDocument();
+  });
+
+  it('should_show_results_when_available', () => {
+    useCortexStore.getState().setQueryResults([
+      { chunkId: 'c1', docId: 'doc-1', content: 'TCP usa three-way handshake', score: 0.9 },
+    ]);
+    render(<NexusContextSurface taskTitle="Estudiar TCP" />);
+    expect(screen.getByTestId('nexus-context-panel')).toBeInTheDocument();
+    expect(screen.getByText(/TCP usa three-way handshake/i)).toBeInTheDocument();
+  });
+
+  it('should_show_task_title_in_panel_header', () => {
+    useCortexStore.getState().setQueryResults([
+      { chunkId: 'c1', docId: 'doc-1', content: 'contenido', score: 0.8 },
+    ]);
+    render(<NexusContextSurface taskTitle="Estudiar UDP" />);
+    expect(screen.getByTestId('nexus-context-panel')).toHaveTextContent(/Estudiar UDP/i);
+  });
+
+  it('should_show_error_state', () => {
+    useCortexStore.getState().setQueryError('índice no disponible');
+    render(<NexusContextSurface taskTitle="Cualquier tarea" />);
+    expect(screen.getByTestId('nexus-context-error')).toHaveTextContent(/índice no disponible/i);
+  });
+
+  it('should_limit_displayed_results_to_3', () => {
+    useCortexStore.getState().setQueryResults([
+      { chunkId: 'c1', docId: 'd1', content: 'Resultado 1', score: 0.9 },
+      { chunkId: 'c2', docId: 'd1', content: 'Resultado 2', score: 0.85 },
+      { chunkId: 'c3', docId: 'd1', content: 'Resultado 3', score: 0.80 },
+      { chunkId: 'c4', docId: 'd1', content: 'Resultado 4', score: 0.75 },
+    ]);
+    render(<NexusContextSurface taskTitle="tarea" />);
+    expect(screen.getAllByTestId('nexus-context-result')).toHaveLength(3);
+  });
+});

--- a/src/cortex/ui/NexusContextSurface.tsx
+++ b/src/cortex/ui/NexusContextSurface.tsx
@@ -1,0 +1,64 @@
+import { useCortexStore, type CortexQueryResult } from './cortexStore';
+
+const MAX_RESULTS = 3;
+
+interface NexusContextSurfaceProps {
+  taskTitle: string;
+}
+
+function ContextResult({ result }: { result: CortexQueryResult }) {
+  return (
+    <li data-testid="nexus-context-result" className="nexus-context-result">
+      <p>{result.content}</p>
+    </li>
+  );
+}
+
+/**
+ * Superficie contextual que aparece al abrir una tarea de Nexus (Kanban).
+ *
+ * Muestra hasta 3 fragmentos del índice RuVector relacionados con el título
+ * de la tarea, para que el usuario tenga contexto relevante de sus apuntes
+ * sin tener que buscar manualmente.
+ *
+ * Si no hay resultados ni carga activa, no renderiza nada (null)
+ * para no ocupar espacio en el panel de la tarea.
+ */
+export function NexusContextSurface({ taskTitle }: NexusContextSurfaceProps) {
+  const results = useCortexStore((s) => s.queryResults);
+  const isQuerying = useCortexStore((s) => s.isQuerying);
+  const queryError = useCortexStore((s) => s.queryError);
+
+  if (isQuerying) {
+    return (
+      <div data-testid="nexus-context-loading" className="nexus-context-loading">
+        Buscando contexto…
+      </div>
+    );
+  }
+
+  if (queryError) {
+    return (
+      <div data-testid="nexus-context-error" className="nexus-context-error">
+        {queryError}
+      </div>
+    );
+  }
+
+  if (results.length === 0) return null;
+
+  const top = results.slice(0, MAX_RESULTS);
+
+  return (
+    <aside data-testid="nexus-context-panel" className="nexus-context-panel">
+      <header className="nexus-context-header">
+        <span>Contexto para: {taskTitle}</span>
+      </header>
+      <ul className="nexus-context-list">
+        {top.map((r) => (
+          <ContextResult key={r.chunkId} result={r} />
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/src/cortex/ui/cortexStore.ts
+++ b/src/cortex/ui/cortexStore.ts
@@ -1,0 +1,70 @@
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+
+export type CortexActivity =
+  | { type: 'idle' }
+  | { type: 'indexing'; docTitle: string; progress?: number }
+  | { type: 'transcribing'; filename: string }
+  | { type: 'querying'; query: string }
+  | { type: 'ocr'; filename: string };
+
+export interface CortexQueryResult {
+  chunkId: string;
+  docId: string;
+  content: string;
+  score: number;
+}
+
+export interface CortexState {
+  activity: CortexActivity;
+  indexedDocCount: number;
+  lastIndexedAt: number | null;
+  queryResults: CortexQueryResult[];
+  isQuerying: boolean;
+  queryError: string | null;
+}
+
+interface CortexActions {
+  setActivity: (activity: CortexActivity) => void;
+  setIndexedDocCount: (count: number) => void;
+  setLastIndexedAt: (ts: number) => void;
+  setQueryResults: (results: CortexQueryResult[]) => void;
+  setIsQuerying: (v: boolean) => void;
+  setQueryError: (err: string | null) => void;
+  reset: () => void;
+}
+
+const initialState: CortexState = {
+  activity: { type: 'idle' },
+  indexedDocCount: 0,
+  lastIndexedAt: null,
+  queryResults: [],
+  isQuerying: false,
+  queryError: null,
+};
+
+export const useCortexStore = create<CortexState & CortexActions>()(
+  immer((set) => ({
+    ...initialState,
+
+    setActivity: (activity) =>
+      set((s) => { s.activity = activity; }),
+
+    setIndexedDocCount: (count) =>
+      set((s) => { s.indexedDocCount = count; }),
+
+    setLastIndexedAt: (ts) =>
+      set((s) => { s.lastIndexedAt = ts; }),
+
+    setQueryResults: (results) =>
+      set((s) => { s.queryResults = results; }),
+
+    setIsQuerying: (v) =>
+      set((s) => { s.isQuerying = v; }),
+
+    setQueryError: (err) =>
+      set((s) => { s.queryError = err; }),
+
+    reset: () => set(() => ({ ...initialState })),
+  })),
+);


### PR DESCRIPTION
## Resumen

- ✅ `cortexStore` — estado Zustand+immer compartido para todos los componentes UI
- ✅ `CortexActivityIndicator` — indicador dinámico de actividad (idle/indexing/transcribing/querying/ocr) (issue #22)
- ✅ `CortexFloatingPanel` — consulta rápida con resultados, loading, error y submit con Enter (issue #20)
- ✅ `CortexTab` — tab dedicado con métricas del índice y actividad actual (issue #21)
- ✅ `NexusContextSurface` — contexto automático al abrir tarea de Nexus, top-3 resultados (issue #23)

## Plan de pruebas

- [x] `npx vitest run src/cortex/` → **112/112 verde** (M1+M2+M3+M4 acumulados)
- [x] Tests de UI con @testing-library/react + jsdom
- [x] mockClear() en beforeEach para evitar contaminación entre tests

Closes #20, #21, #22, #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)