### PR TITLE
feat(cortex): M6 Advanced Features — AutoResearch, Updater, Health

### DIFF
--- a/src/cortex/health/HealthMetrics.test.ts
+++ b/src/cortex/health/HealthMetrics.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { HealthMetrics, type HealthSnapshot } from './HealthMetrics';
+
+function makeSnapshot(overrides: Partial<HealthSnapshot> = {}): HealthSnapshot {
+  return {
+    avgLatencyMs: 120,
+    successRate: 0.98,
+    indexedDocCount: 200,
+    indexSizeBytes: 500 * 1024 * 1024, // 500 MB
+    sampledAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('HealthMetrics — computeStatus', () => {
+  it('should_return_healthy_when_all_metrics_are_nominal', () => {
+    const m = new HealthMetrics();
+    const status = m.computeStatus(makeSnapshot());
+    expect(status.overall).toBe('healthy');
+    expect(status.alerts).toHaveLength(0);
+  });
+
+  it('should_alert_when_index_exceeds_2GB', () => {
+    const m = new HealthMetrics();
+    const snapshot = makeSnapshot({ indexSizeBytes: 2.1 * 1024 ** 3 });
+    const status = m.computeStatus(snapshot);
+    expect(status.alerts.some((a) => a.type === 'index_size')).toBe(true);
+  });
+
+  it('should_return_degraded_when_success_rate_below_90_percent', () => {
+    const m = new HealthMetrics();
+    const status = m.computeStatus(makeSnapshot({ successRate: 0.85 }));
+    expect(status.overall).toBe('degraded');
+    expect(status.alerts.some((a) => a.type === 'low_success_rate')).toBe(true);
+  });
+
+  it('should_return_degraded_when_avg_latency_exceeds_5000ms', () => {
+    const m = new HealthMetrics();
+    const status = m.computeStatus(makeSnapshot({ avgLatencyMs: 6000 }));
+    expect(status.overall).toBe('degraded');
+    expect(status.alerts.some((a) => a.type === 'high_latency')).toBe(true);
+  });
+
+  it('should_return_healthy_at_exactly_2GB_index', () => {
+    const m = new HealthMetrics();
+    const status = m.computeStatus(makeSnapshot({ indexSizeBytes: 2 * 1024 ** 3 }));
+    expect(status.alerts.some((a) => a.type === 'index_size')).toBe(false);
+  });
+
+  it('should_accumulate_multiple_alerts', () => {
+    const m = new HealthMetrics();
+    const status = m.computeStatus(makeSnapshot({
+      successRate: 0.80,
+      avgLatencyMs: 7000,
+      indexSizeBytes: 3 * 1024 ** 3,
+    }));
+    expect(status.alerts).toHaveLength(3);
+    expect(status.overall).toBe('degraded');
+  });
+});
+
+describe('HealthMetrics — record y avgLatency', () => {
+  it('should_compute_avg_latency_from_recorded_samples', () => {
+    const m = new HealthMetrics();
+    m.recordLatency(100);
+    m.recordLatency(200);
+    m.recordLatency(300);
+    expect(m.getAvgLatencyMs()).toBe(200);
+  });
+
+  it('should_return_zero_avg_when_no_samples', () => {
+    const m = new HealthMetrics();
+    expect(m.getAvgLatencyMs()).toBe(0);
+  });
+
+  it('should_compute_success_rate_from_recorded_operations', () => {
+    const m = new HealthMetrics();
+    m.recordOperation({ success: true });
+    m.recordOperation({ success: true });
+    m.recordOperation({ success: false });
+    expect(m.getSuccessRate()).toBeCloseTo(0.6667, 2);
+  });
+
+  it('should_return_1_when_no_operations_recorded', () => {
+    const m = new HealthMetrics();
+    expect(m.getSuccessRate()).toBe(1);
+  });
+
+  it('should_only_keep_last_24h_of_samples', () => {
+    const m = new HealthMetrics();
+    // Simular muestra antigua (>24h)
+    m.recordLatency(9999, Date.now() - 25 * 3_600_000);
+    m.recordLatency(100); // reciente
+    expect(m.getAvgLatencyMs()).toBe(100);
+  });
+});

--- a/src/cortex/health/HealthMetrics.ts
+++ b/src/cortex/health/HealthMetrics.ts
@@ -1,0 +1,94 @@
+const INDEX_SIZE_ALERT_BYTES = 2 * 1024 ** 3; // 2 GB
+const LATENCY_ALERT_MS = 5_000;
+const SUCCESS_RATE_ALERT = 0.9;
+const WINDOW_MS = 24 * 60 * 60 * 1000; // 24 horas
+
+export type OverallStatus = 'healthy' | 'degraded';
+export type AlertType = 'index_size' | 'low_success_rate' | 'high_latency';
+
+export interface HealthAlert {
+  type: AlertType;
+  message: string;
+}
+
+export interface HealthStatus {
+  overall: OverallStatus;
+  alerts: HealthAlert[];
+}
+
+export interface HealthSnapshot {
+  avgLatencyMs: number;
+  successRate: number;
+  indexedDocCount: number;
+  indexSizeBytes: number;
+  sampledAt: number;
+}
+
+interface LatencySample { value: number; ts: number }
+interface OpSample { success: boolean; ts: number }
+
+/**
+ * Recopila y evalúa métricas de salud de Cortex en tiempo real.
+ *
+ * Umbrales:
+ * - índice > 2 GB → alerta index_size
+ * - tasa de éxito < 90% → degraded + alerta low_success_rate
+ * - latencia promedio > 5000ms → degraded + alerta high_latency
+ *
+ * Las muestras de latencia y operaciones solo consideran las últimas 24h.
+ */
+export class HealthMetrics {
+  private latencies: LatencySample[] = [];
+  private operations: OpSample[] = [];
+
+  recordLatency(ms: number, ts = Date.now()): void {
+    this.latencies.push({ value: ms, ts });
+  }
+
+  recordOperation(op: { success: boolean }, ts = Date.now()): void {
+    this.operations.push({ success: op.success, ts });
+  }
+
+  getAvgLatencyMs(): number {
+    const recent = this.recentLatencies();
+    if (recent.length === 0) return 0;
+    return recent.reduce((sum, s) => sum + s.value, 0) / recent.length;
+  }
+
+  getSuccessRate(): number {
+    const recent = this.recentOps();
+    if (recent.length === 0) return 1;
+    return recent.filter((o) => o.success).length / recent.length;
+  }
+
+  computeStatus(snapshot: HealthSnapshot): HealthStatus {
+    const alerts: HealthAlert[] = [];
+
+    if (snapshot.indexSizeBytes > INDEX_SIZE_ALERT_BYTES) {
+      const gb = (snapshot.indexSizeBytes / 1024 ** 3).toFixed(1);
+      alerts.push({ type: 'index_size', message: `Índice ocupa ${gb} GB (límite: 2 GB)` });
+    }
+
+    if (snapshot.successRate < SUCCESS_RATE_ALERT) {
+      const pct = (snapshot.successRate * 100).toFixed(0);
+      alerts.push({ type: 'low_success_rate', message: `Tasa de éxito: ${pct}% (mínimo: 90%)` });
+    }
+
+    if (snapshot.avgLatencyMs > LATENCY_ALERT_MS) {
+      alerts.push({ type: 'high_latency', message: `Latencia promedio: ${snapshot.avgLatencyMs}ms (límite: 5000ms)` });
+    }
+
+    const overall: OverallStatus = alerts.length > 0 ? 'degraded' : 'healthy';
+    return { overall, alerts };
+  }
+
+  private recentLatencies(): LatencySample[] {
+    const cutoff = Date.now() - WINDOW_MS;
+    return this.latencies.filter((s) => s.ts >= cutoff);
+  }
+
+  private recentOps(): OpSample[] {
+    const cutoff = Date.now() - WINDOW_MS;
+    return this.operations.filter((s) => s.ts >= cutoff);
+  }
+}

--- a/src/cortex/research/AutoResearchClaw.test.ts
+++ b/src/cortex/research/AutoResearchClaw.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AutoResearchClaw } from './AutoResearchClaw';
+
+function makePaperClient() {
+  return {
+    search: vi.fn().mockResolvedValue([
+      { id: 'p1', title: 'TCP Congestion Control', abstract: 'Estudio sobre control de congestión.', url: 'https://arxiv.org/p1' },
+      { id: 'p2', title: 'UDP vs TCP Latency', abstract: 'Comparativa de latencias.', url: 'https://arxiv.org/p2' },
+    ]),
+  };
+}
+
+function makeIndexer() {
+  return {
+    indexDocument: vi.fn().mockResolvedValue({ chunks: 3 }),
+  };
+}
+
+describe('AutoResearchClaw — búsqueda', () => {
+  let client: ReturnType<typeof makePaperClient>;
+  let indexer: ReturnType<typeof makeIndexer>;
+  let claw: AutoResearchClaw;
+
+  beforeEach(() => {
+    client = makePaperClient();
+    indexer = makeIndexer();
+    claw = new AutoResearchClaw({ client: client as never, indexer: indexer as never });
+  });
+
+  it('should_search_papers_and_return_pending_results', async () => {
+    const results = await claw.search('TCP congestion control');
+    expect(client.search).toHaveBeenCalledWith('TCP congestion control');
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.status === 'pending')).toBe(true);
+  });
+
+  it('should_include_title_abstract_and_url_in_each_result', async () => {
+    const results = await claw.search('TCP');
+    expect(results[0].title).toBe('TCP Congestion Control');
+    expect(results[0].abstract).toBeDefined();
+    expect(results[0].url).toContain('arxiv.org');
+  });
+
+  it('should_not_auto_import_anything_without_approval', async () => {
+    await claw.search('TCP');
+    expect(indexer.indexDocument).not.toHaveBeenCalled();
+  });
+
+  it('should_return_empty_array_when_no_results_found', async () => {
+    client.search.mockResolvedValueOnce([]);
+    const results = await claw.search('tema sin papers');
+    expect(results).toHaveLength(0);
+  });
+});
+
+describe('AutoResearchClaw — aprobación individual (REQ-08)', () => {
+  let client: ReturnType<typeof makePaperClient>;
+  let indexer: ReturnType<typeof makeIndexer>;
+  let claw: AutoResearchClaw;
+
+  beforeEach(() => {
+    client = makePaperClient();
+    indexer = makeIndexer();
+    claw = new AutoResearchClaw({ client: client as never, indexer: indexer as never });
+  });
+
+  it('should_index_paper_when_approved', async () => {
+    const results = await claw.search('TCP');
+    await claw.approve(results[0].id);
+    expect(indexer.indexDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ docId: results[0].id })
+    );
+  });
+
+  it('should_mark_result_as_approved_after_approval', async () => {
+    const results = await claw.search('TCP');
+    await claw.approve(results[0].id);
+    const updated = claw.getPendingResults();
+    expect(updated.find((r) => r.id === results[0].id)?.status).toBe('approved');
+  });
+
+  it('should_not_index_paper_when_rejected', async () => {
+    const results = await claw.search('TCP');
+    claw.reject(results[1].id);
+    expect(indexer.indexDocument).not.toHaveBeenCalled();
+  });
+
+  it('should_mark_result_as_rejected_after_rejection', async () => {
+    const results = await claw.search('TCP');
+    claw.reject(results[0].id);
+    expect(claw.getPendingResults().find((r) => r.id === results[0].id)?.status).toBe('rejected');
+  });
+
+  it('should_throw_when_approving_unknown_id', async () => {
+    await claw.search('TCP');
+    await expect(claw.approve('ghost-id')).rejects.toThrow('not found');
+  });
+
+  it('should_allow_approving_only_one_result_independently', async () => {
+    const results = await claw.search('TCP');
+    await claw.approve(results[0].id); // solo el primero
+    expect(indexer.indexDocument).toHaveBeenCalledTimes(1);
+    const pending = claw.getPendingResults();
+    expect(pending.find((r) => r.id === results[1].id)?.status).toBe('pending');
+  });
+});

--- a/src/cortex/research/AutoResearchClaw.ts
+++ b/src/cortex/research/AutoResearchClaw.ts
@@ -1,0 +1,78 @@
+export type PaperStatus = 'pending' | 'approved' | 'rejected';
+
+export interface PaperResult {
+  id: string;
+  title: string;
+  abstract: string;
+  url: string;
+  status: PaperStatus;
+}
+
+export interface PaperSearchClient {
+  search(query: string): Promise<Omit<PaperResult, 'status'>[]>;
+}
+
+export interface PaperIndexer {
+  indexDocument(req: { docId: string; path: string; mimeType: string }): Promise<{ chunks: number }>;
+}
+
+interface AutoResearchClawOptions {
+  client: PaperSearchClient;
+  indexer: PaperIndexer;
+}
+
+/**
+ * Módulo de investigación automática de papers académicos.
+ *
+ * REQ-08: Ningún resultado se importa al índice sin aprobación
+ * explícita del usuario. El flujo es:
+ *   1. search() → devuelve resultados con status="pending"
+ *   2. Usuario aprueba o rechaza cada resultado individualmente
+ *   3. approve(id) → indexa el paper aprobado
+ *   4. reject(id) → descarta sin indexar
+ *
+ * Nota: Esta es la única operación de Cortex que requiere internet.
+ */
+export class AutoResearchClaw {
+  private readonly client: PaperSearchClient;
+  private readonly indexer: PaperIndexer;
+  private results: Map<string, PaperResult> = new Map();
+
+  constructor({ client, indexer }: AutoResearchClawOptions) {
+    this.client = client;
+    this.indexer = indexer;
+  }
+
+  /** Busca papers y devuelve todos en estado "pending". No indexa nada. */
+  async search(query: string): Promise<PaperResult[]> {
+    const raw = await this.client.search(query);
+    this.results = new Map(
+      raw.map((p) => [p.id, { ...p, status: 'pending' as PaperStatus }])
+    );
+    return [...this.results.values()];
+  }
+
+  /** Aprueba e indexa un paper individual. Lanza si el id no existe. */
+  async approve(id: string): Promise<void> {
+    const paper = this.results.get(id);
+    if (!paper) throw new Error(`AutoResearchClaw: paper "${id}" not found`);
+
+    paper.status = 'approved';
+    await this.indexer.indexDocument({
+      docId: paper.id,
+      path: paper.url,
+      mimeType: 'text/html',
+    });
+  }
+
+  /** Rechaza un paper — no lo indexa. */
+  reject(id: string): void {
+    const paper = this.results.get(id);
+    if (paper) paper.status = 'rejected';
+  }
+
+  /** Retorna todos los resultados de la última búsqueda con su estado actual. */
+  getPendingResults(): PaperResult[] {
+    return [...this.results.values()];
+  }
+}

--- a/src/cortex/updater/UpdaterConfig.test.ts
+++ b/src/cortex/updater/UpdaterConfig.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpdaterConfig, type UpdateChannel } from './UpdaterConfig';
+
+function makeUpdaterClient() {
+  return {
+    setChannel: vi.fn().mockResolvedValue(undefined),
+    getChannel: vi.fn().mockReturnValue('stable' as UpdateChannel),
+    checkForUpdates: vi.fn().mockResolvedValue({ available: false }),
+  };
+}
+
+describe('UpdaterConfig — canal por defecto', () => {
+  it('should_default_to_stable_channel', () => {
+    const client = makeUpdaterClient();
+    const config = new UpdaterConfig({ client: client as never });
+    expect(config.getChannel()).toBe('stable');
+  });
+});
+
+describe('UpdaterConfig — opt-in beta', () => {
+  let client: ReturnType<typeof makeUpdaterClient>;
+  let config: UpdaterConfig;
+
+  beforeEach(() => {
+    client = makeUpdaterClient();
+    config = new UpdaterConfig({ client: client as never });
+  });
+
+  it('should_switch_to_beta_when_opted_in', async () => {
+    await config.setChannel('beta');
+    expect(client.setChannel).toHaveBeenCalledWith('beta');
+  });
+
+  it('should_return_beta_after_opt_in', async () => {
+    client.getChannel.mockReturnValue('beta');
+    await config.setChannel('beta');
+    expect(config.getChannel()).toBe('beta');
+  });
+
+  it('should_switch_back_to_stable_when_opting_out', async () => {
+    await config.setChannel('beta');
+    await config.setChannel('stable');
+    expect(client.setChannel).toHaveBeenLastCalledWith('stable');
+  });
+
+  it('should_not_call_setChannel_if_already_on_that_channel', async () => {
+    // Ya está en stable por defecto
+    await config.setChannel('stable');
+    expect(client.setChannel).not.toHaveBeenCalled();
+  });
+});
+
+describe('UpdaterConfig — verificación de updates', () => {
+  it('should_check_for_updates_and_return_result', async () => {
+    const client = makeUpdaterClient();
+    client.checkForUpdates.mockResolvedValueOnce({ available: true, version: '2.1.0' });
+    const config = new UpdaterConfig({ client: client as never });
+    const result = await config.checkForUpdates();
+    expect(result.available).toBe(true);
+    expect(result.version).toBe('2.1.0');
+  });
+
+  it('should_return_not_available_when_up_to_date', async () => {
+    const client = makeUpdaterClient();
+    const config = new UpdaterConfig({ client: client as never });
+    const result = await config.checkForUpdates();
+    expect(result.available).toBe(false);
+  });
+});

--- a/src/cortex/updater/UpdaterConfig.ts
+++ b/src/cortex/updater/UpdaterConfig.ts
@@ -1,0 +1,50 @@
+export type UpdateChannel = 'stable' | 'beta';
+
+export interface UpdateCheckResult {
+  available: boolean;
+  version?: string;
+}
+
+export interface ElectronUpdaterClient {
+  setChannel(channel: UpdateChannel): Promise<void>;
+  getChannel(): UpdateChannel;
+  checkForUpdates(): Promise<UpdateCheckResult>;
+}
+
+interface UpdaterConfigOptions {
+  client: ElectronUpdaterClient;
+}
+
+/**
+ * Gestiona la configuración del canal de actualización (stable / beta).
+ *
+ * Por defecto: canal estable (latest.yml en GitHub Releases).
+ * Beta: opt-in explícito en configuración → beta.yml.
+ *
+ * El cliente real en producción wrappea electron-updater.
+ * En tests se inyecta un mock para no depender de Electron.
+ */
+export class UpdaterConfig {
+  private readonly client: ElectronUpdaterClient;
+  private currentChannel: UpdateChannel;
+
+  constructor({ client }: UpdaterConfigOptions) {
+    this.client = client;
+    this.currentChannel = client.getChannel();
+  }
+
+  getChannel(): UpdateChannel {
+    return this.currentChannel;
+  }
+
+  /** Cambia el canal. No-op si ya está en ese canal. */
+  async setChannel(channel: UpdateChannel): Promise<void> {
+    if (this.currentChannel === channel) return;
+    await this.client.setChannel(channel);
+    this.currentChannel = channel;
+  }
+
+  async checkForUpdates(): Promise<UpdateCheckResult> {
+    return this.client.checkForUpdates();
+  }
+}


### PR DESCRIPTION
## Resumen

- ✅ `AutoResearchClaw` — búsqueda de papers con aprobación individual por resultado (REQ-08). Ningún paper se indexa sin acción explícita del usuario (issue #26)
- ✅ `UpdaterConfig` — canal stable/beta opt-in, no-op si ya en ese canal, currentChannel trackeado localmente (issue #27)
- ✅ `HealthMetrics` — latencias/operaciones con ventana 24h, alertas index_size/low_success_rate/high_latency, estado healthy/degraded (issue #28)

## Plan de pruebas

- [x] `npx vitest run src/cortex/` → **158/158 verde** (M1→M6 acumulados)
- [x] AutoResearchClaw: `approve()` solo llama al indexer 1x por resultado aprobado
- [x] HealthMetrics: muestras >24h excluidas del cálculo de promedios
- [x] UpdaterConfig: no-op cuando canal ya es el solicitado

Closes #26, #27, #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)