### PR TITLE
test(v3.3.0): Cobertura de tests — AI, crypto, embeddings, stores, domain

### DIFF
--- a/src/domain/progressAnalysis.test.ts
+++ b/src/domain/progressAnalysis.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { CURRICULUM, TOTAL_CREDITS } from "../data/lti";
+import type { SubjectData } from "../hooks/useSubjectData";
+import {
+	calculateProgressStats,
+	calculateSemesterAverages,
+} from "./progressAnalysis";
+
+// Construir un mapa vacío (todas las materias en estado por defecto)
+function emptyData(): Record<string, SubjectData> {
+	return {};
+}
+
+// Construir un mapa con todas las materias aprobadas con nota
+function approveAll(grade = 8): Record<string, SubjectData> {
+	const data: Record<string, SubjectData> = {};
+	for (const sem of CURRICULUM) {
+		for (const sub of sem.subjects) {
+			data[sub.id] = { status: "aprobada", grade };
+		}
+	}
+	return data;
+}
+
+// Construir un mapa con algunas materias en curso
+function someInProgress(ids: string[]): Record<string, SubjectData> {
+	const data: Record<string, SubjectData> = {};
+	for (const id of ids) {
+		data[id] = { status: "en_curso" };
+	}
+	return data;
+}
+
+describe("calculateProgressStats", () => {
+	it("data vacía → 0 aprobados, 0 en curso, totalMissing = TOTAL_CREDITS", () => {
+		const stats = calculateProgressStats(emptyData());
+		expect(stats.totalApproved).toBe(0);
+		expect(stats.totalInProgress).toBe(0);
+		expect(stats.totalMissing).toBe(TOTAL_CREDITS);
+	});
+
+	it("todas aprobadas → totalApproved = TOTAL_CREDITS, missing = 0", () => {
+		const stats = calculateProgressStats(approveAll());
+		expect(stats.totalApproved).toBe(TOTAL_CREDITS);
+		expect(stats.totalMissing).toBe(0);
+		expect(stats.totalInProgress).toBe(0);
+	});
+
+	it("totalApproved + totalInProgress + totalMissing siempre = TOTAL_CREDITS", () => {
+		const firstSubject = CURRICULUM[0].subjects[0];
+		const data = someInProgress([firstSubject.id]);
+		const stats = calculateProgressStats(data);
+		expect(
+			stats.totalApproved + stats.totalInProgress + stats.totalMissing,
+		).toBe(TOTAL_CREDITS);
+	});
+
+	it("materias en curso suman créditos correctamente", () => {
+		const firstTwoSubs = CURRICULUM[0].subjects.slice(0, 2);
+		const expectedCredits = firstTwoSubs.reduce((acc, s) => acc + s.credits, 0);
+		const data = someInProgress(firstTwoSubs.map((s) => s.id));
+		const stats = calculateProgressStats(data);
+		expect(stats.totalInProgress).toBe(expectedCredits);
+	});
+
+	it("status desconocido no cuenta como aprobada ni en_curso", () => {
+		const id = CURRICULUM[0].subjects[0].id;
+		const data: Record<string, SubjectData> = {
+			[id]: { status: "pendiente" },
+		};
+		const stats = calculateProgressStats(data);
+		expect(stats.totalApproved).toBe(0);
+		expect(stats.totalInProgress).toBe(0);
+	});
+});
+
+describe("calculateSemesterAverages", () => {
+	it("data vacía → todos los semestres con Promedio 0", () => {
+		const averages = calculateSemesterAverages(emptyData());
+		expect(averages).toHaveLength(CURRICULUM.length);
+		for (const avg of averages) {
+			expect(avg.Promedio).toBe(0);
+		}
+	});
+
+	it("nombres siguen el formato S1, S2, ..., S8", () => {
+		const averages = calculateSemesterAverages(emptyData());
+		averages.forEach((avg, i) => {
+			expect(avg.name).toBe(`S${CURRICULUM[i].number}`);
+		});
+	});
+
+	it("promedio correcto cuando todas las materias del semestre tienen nota", () => {
+		const sem = CURRICULUM[0];
+		const data: Record<string, SubjectData> = {};
+		for (const sub of sem.subjects) {
+			data[sub.id] = { status: "aprobada", grade: 10 };
+		}
+		const averages = calculateSemesterAverages(data);
+		expect(averages[0].Promedio).toBe(10);
+	});
+
+	it("ignora materias aprobadas sin grade en el cálculo", () => {
+		const sem = CURRICULUM[0];
+		const data: Record<string, SubjectData> = {};
+		for (const sub of sem.subjects) {
+			data[sub.id] = { status: "aprobada" }; // sin grade
+		}
+		const averages = calculateSemesterAverages(data);
+		// Sin notas, el filtro excluye todas → Promedio 0
+		expect(averages[0].Promedio).toBe(0);
+	});
+
+	it("Promedio tiene como máximo 1 decimal", () => {
+		const sem = CURRICULUM[0];
+		const data: Record<string, SubjectData> = {};
+		sem.subjects.forEach((sub, i) => {
+			data[sub.id] = { status: "aprobada", grade: i % 2 === 0 ? 7 : 8 };
+		});
+		const averages = calculateSemesterAverages(data);
+		const promedioStr = averages[0].Promedio.toString();
+		const decimals = promedioStr.includes(".")
+			? promedioStr.split(".")[1].length
+			: 0;
+		expect(decimals).toBeLessThanOrEqual(1);
+	});
+});

--- a/src/store/aetherStore.test.ts
+++ b/src/store/aetherStore.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock idb-keyval para que persist no intente usar IndexedDB en tests
+vi.mock("idb-keyval", () => ({
+	get: vi.fn().mockResolvedValue(undefined),
+	set: vi.fn().mockResolvedValue(undefined),
+	del: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock security utils (obfuscate/deobfuscate son async, devuelven el valor tal cual en tests)
+vi.mock("../utils/security", () => ({
+	obfuscate: vi.fn((v: string) => Promise.resolve(v)),
+	deobfuscate: vi.fn((v: unknown) =>
+		Promise.resolve(typeof v === "string" ? v : null),
+	),
+}));
+
+import { useAetherStore } from "./aetherStore";
+
+function resetStore() {
+	useAetherStore.setState({
+		notes: [],
+		chatHistory: [],
+		geminiApiKey: "",
+		gmailClientId: "",
+		gmailApiKey: "",
+	});
+}
+
+describe("aetherStore — mutaciones de notas", () => {
+	beforeEach(resetStore);
+	afterEach(resetStore);
+
+	it("addNote crea una nota con título por defecto", () => {
+		const note = useAetherStore.getState().addNote();
+		const { notes } = useAetherStore.getState();
+		expect(notes).toHaveLength(1);
+		expect(note.title).toBe("Nueva Nota");
+		expect(note.id).toMatch(/^note_/);
+	});
+
+	it("addNote con título personalizado", () => {
+		const note = useAetherStore.getState().addNote("Mi Apunte");
+		expect(note.title).toBe("Mi Apunte");
+	});
+
+	it("addNote agrega al inicio (unshift)", () => {
+		useAetherStore.getState().addNote("Primera");
+		useAetherStore.getState().addNote("Segunda");
+		const { notes } = useAetherStore.getState();
+		expect(notes[0].title).toBe("Segunda");
+		expect(notes[1].title).toBe("Primera");
+	});
+
+	it("updateNote cambia título y actualiza updatedAt", async () => {
+		const note = useAetherStore.getState().addNote("Original");
+		const before = note.updatedAt;
+
+		await new Promise((r) => setTimeout(r, 5));
+
+		useAetherStore.getState().updateNote(note.id, { title: "Modificado" });
+		const updated = useAetherStore.getState().getNote(note.id);
+		expect(updated?.title).toBe("Modificado");
+		expect(updated?.updatedAt).toBeGreaterThan(before);
+	});
+
+	it("updateNote en id inexistente no lanza ni cambia el store", () => {
+		useAetherStore.getState().addNote("Existente");
+		expect(() =>
+			useAetherStore
+				.getState()
+				.updateNote("note_inexistente" as any, { title: "X" }),
+		).not.toThrow();
+		expect(useAetherStore.getState().notes).toHaveLength(1);
+	});
+
+	it("deleteNote elimina la nota correcta", () => {
+		const a = useAetherStore.getState().addNote("A");
+		const b = useAetherStore.getState().addNote("B");
+		useAetherStore.getState().deleteNote(a.id);
+		const { notes } = useAetherStore.getState();
+		expect(notes).toHaveLength(1);
+		expect(notes[0].id).toBe(b.id);
+	});
+
+	it("getNote devuelve la nota correcta por id", () => {
+		const note = useAetherStore.getState().addNote("Buscable");
+		const found = useAetherStore.getState().getNote(note.id);
+		expect(found).toBeDefined();
+		expect(found?.title).toBe("Buscable");
+	});
+
+	it("getNote devuelve undefined para id inexistente", () => {
+		expect(
+			useAetherStore.getState().getNote("note_nada" as any),
+		).toBeUndefined();
+	});
+});
+
+describe("aetherStore — getGraphData (O(n) con Map)", () => {
+	beforeEach(resetStore);
+	afterEach(resetStore);
+
+	it("notas sin links → nodes correctos, sin links", () => {
+		useAetherStore.getState().addNote("A");
+		useAetherStore.getState().addNote("B");
+		const { nodes, links } = useAetherStore.getState().getGraphData();
+		expect(nodes).toHaveLength(2);
+		expect(links).toHaveLength(0);
+	});
+
+	it("nota con [[link]] al título de otra genera un link", () => {
+		useAetherStore
+			.getState()
+			.updateNote(useAetherStore.getState().addNote("Destino").id, {
+				content: "",
+			});
+		const origen = useAetherStore.getState().addNote("Origen");
+		useAetherStore
+			.getState()
+			.updateNote(origen.id, { content: "Esto enlaza [[Destino]]" });
+
+		const { links } = useAetherStore.getState().getGraphData();
+		expect(links).toHaveLength(1);
+	});
+
+	it("link a título inexistente no genera edge", () => {
+		const note = useAetherStore.getState().addNote("Sola");
+		useAetherStore.getState().updateNote(note.id, { content: "[[NoExiste]]" });
+		const { links } = useAetherStore.getState().getGraphData();
+		expect(links).toHaveLength(0);
+	});
+});
+
+describe("aetherStore — findBacklinks", () => {
+	beforeEach(resetStore);
+	afterEach(resetStore);
+
+	it("encuentra notas que apuntan al nodo dado", () => {
+		const dest = useAetherStore.getState().addNote("Destino");
+		const src = useAetherStore.getState().addNote("Fuente");
+		useAetherStore
+			.getState()
+			.updateNote(src.id, { content: "Ver [[Destino]] para más info" });
+
+		const backlinks = useAetherStore.getState().findBacklinks(dest.id);
+		expect(backlinks.map((n) => n.id)).toContain(src.id);
+	});
+
+	it("no incluye la nota como backlink de sí misma", () => {
+		const note = useAetherStore.getState().addNote("Circular");
+		useAetherStore.getState().updateNote(note.id, { content: "[[Circular]]" });
+		const backlinks = useAetherStore.getState().findBacklinks(note.id);
+		expect(backlinks.map((n) => n.id)).not.toContain(note.id);
+	});
+
+	it("devuelve [] si el nodo no existe", () => {
+		expect(
+			useAetherStore.getState().findBacklinks("note_ghost" as any),
+		).toEqual([]);
+	});
+});

--- a/src/store/nexusStore.test.ts
+++ b/src/store/nexusStore.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// nexusStore usa IndexeddbPersistence de yjs — mock para no tocar IDB en tests
+vi.mock("y-indexeddb", () => ({
+	IndexeddbPersistence: vi.fn().mockImplementation(() => ({})),
+}));
+
+import { useNexusStore } from "./nexusStore";
+
+function resetStore() {
+	useNexusStore.setState({
+		documents: [],
+		yDocs: {},
+		yDocsCreating: new Set(),
+	});
+}
+
+describe("nexusStore — mutaciones de documentos", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		resetStore();
+	});
+	afterEach(() => {
+		localStorage.clear();
+		resetStore();
+	});
+
+	it("addDocument crea un doc con título por defecto", () => {
+		const doc = useNexusStore.getState().addDocument();
+		expect(doc.title).toBe("Página sin título");
+		expect(doc.id).toMatch(/^doc_/);
+		expect(useNexusStore.getState().documents).toHaveLength(1);
+	});
+
+	it("addDocument con título personalizado", () => {
+		const doc = useNexusStore.getState().addDocument("Notas de clase");
+		expect(doc.title).toBe("Notas de clase");
+	});
+
+	it("addDocument inserta al inicio (unshift)", () => {
+		useNexusStore.getState().addDocument("Primero");
+		useNexusStore.getState().addDocument("Segundo");
+		const { documents } = useNexusStore.getState();
+		expect(documents[0].title).toBe("Segundo");
+	});
+
+	it("updateDocument cambia título y actualiza updatedAt", async () => {
+		const doc = useNexusStore.getState().addDocument("Original");
+		const before = doc.updatedAt;
+
+		await new Promise((r) => setTimeout(r, 5));
+
+		useNexusStore.getState().updateDocument(doc.id, { title: "Editado" });
+		const updated = useNexusStore.getState().getDocument(doc.id);
+		expect(updated?.title).toBe("Editado");
+		expect(updated?.updatedAt).toBeGreaterThan(before);
+	});
+
+	it("updateDocument en id inexistente no lanza", () => {
+		expect(() =>
+			useNexusStore
+				.getState()
+				.updateDocument("doc_ghost" as any, { title: "X" }),
+		).not.toThrow();
+	});
+
+	it("deleteDocument elimina el documento correcto", () => {
+		const a = useNexusStore.getState().addDocument("A");
+		const b = useNexusStore.getState().addDocument("B");
+		useNexusStore.getState().deleteDocument(a.id);
+		const { documents } = useNexusStore.getState();
+		expect(documents).toHaveLength(1);
+		expect(documents[0].id).toBe(b.id);
+	});
+
+	it("getDocument retorna el doc por id", () => {
+		const doc = useNexusStore.getState().addDocument("Buscable");
+		expect(useNexusStore.getState().getDocument(doc.id)?.title).toBe(
+			"Buscable",
+		);
+	});
+
+	it("getDocument retorna undefined para id inexistente", () => {
+		expect(
+			useNexusStore.getState().getDocument("doc_nada" as any),
+		).toBeUndefined();
+	});
+
+	it("persiste documentos en localStorage tras addDocument", () => {
+		useNexusStore.getState().addDocument("Persistido");
+		const raw = localStorage.getItem("lti_nexus_docs");
+		expect(raw).not.toBeNull();
+		const parsed = JSON.parse(raw!);
+		expect(parsed[0].title).toBe("Persistido");
+	});
+});

--- a/src/utils/aiUtils.test.ts
+++ b/src/utils/aiUtils.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import {
+	generateContentWithRetry,
+	generateStructuredContentWithRetry,
+	truncateContext,
+} from "./aiUtils";
+
+// --- truncateContext ---
+
+describe("truncateContext", () => {
+	it("devuelve el texto sin cambios si es menor al límite", () => {
+		const text = "Hola mundo";
+		expect(truncateContext(text, 100)).toBe(text);
+	});
+
+	it("trunca exactamente en maxChars", () => {
+		const text = "a".repeat(200);
+		const result = truncateContext(text, 100);
+		expect(result.startsWith("a".repeat(100))).toBe(true);
+		expect(result).toContain("[Contenido truncado");
+	});
+
+	it("no trunca texto igual a maxChars", () => {
+		const text = "x".repeat(50);
+		expect(truncateContext(text, 50)).toBe(text);
+	});
+});
+
+// --- generateContentWithRetry ---
+
+describe("generateContentWithRetry", () => {
+	it("devuelve resultado en el primer intento exitoso", async () => {
+		const mockAi = {
+			models: { generateContent: vi.fn().mockResolvedValue({ text: "ok" }) },
+		} as any;
+
+		const result = await generateContentWithRetry(mockAi, {}, 3);
+		expect(result).toEqual({ text: "ok" });
+		expect(mockAi.models.generateContent).toHaveBeenCalledTimes(1);
+	});
+
+	it("reintenta en error 429 y eventualmente lanza si se agotan intentos", async () => {
+		const error429 = Object.assign(new Error("rate limited"), { status: 429 });
+		const mockAi = {
+			models: { generateContent: vi.fn().mockRejectedValue(error429) },
+		} as any;
+
+		await expect(generateContentWithRetry(mockAi, {}, 2)).rejects.toThrow(
+			"rate limited",
+		);
+		// maxRetries=2: intento 0 falla → reintenta → intento 1 falla → lanza
+		expect(mockAi.models.generateContent).toHaveBeenCalledTimes(2);
+	}, 10000);
+
+	it("lanza inmediatamente en error no retryable (4xx distinto de 429)", async () => {
+		const error400 = Object.assign(new Error("bad request"), { status: 400 });
+		const mockAi = {
+			models: { generateContent: vi.fn().mockRejectedValue(error400) },
+		} as any;
+
+		await expect(generateContentWithRetry(mockAi, {}, 3)).rejects.toThrow(
+			"bad request",
+		);
+		expect(mockAi.models.generateContent).toHaveBeenCalledTimes(1);
+	});
+
+	it("reintenta en error de red (fetch failed)", async () => {
+		const networkError = new Error("fetch failed");
+		const mockAi = {
+			models: {
+				generateContent: vi
+					.fn()
+					.mockRejectedValueOnce(networkError)
+					.mockResolvedValueOnce({ text: "recovered" }),
+			},
+		} as any;
+
+		const result = await generateContentWithRetry(mockAi, {}, 3);
+		expect(result).toEqual({ text: "recovered" });
+		expect(mockAi.models.generateContent).toHaveBeenCalledTimes(2);
+	}, 5000);
+});
+
+// --- generateStructuredContentWithRetry ---
+
+describe("generateStructuredContentWithRetry", () => {
+	const schema = z.object({ answer: z.string() });
+	const geminiSchema = {};
+
+	it("retorna ok con datos válidos", async () => {
+		const mockAi = {
+			models: {
+				generateContent: vi
+					.fn()
+					.mockResolvedValue({ text: JSON.stringify({ answer: "hola" }) }),
+			},
+		} as any;
+
+		const result = await generateStructuredContentWithRetry(
+			mockAi,
+			{},
+			schema,
+			geminiSchema,
+		);
+		expect(result.ok).toBe(true);
+		if (result.ok) expect(result.value.answer).toBe("hola");
+	});
+
+	it("retorna err si el texto está vacío", async () => {
+		const mockAi = {
+			models: { generateContent: vi.fn().mockResolvedValue({ text: "" }) },
+		} as any;
+
+		const result = await generateStructuredContentWithRetry(
+			mockAi,
+			{},
+			schema,
+			geminiSchema,
+		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error.message).toContain("vacía");
+	});
+
+	it("retorna err si el JSON es inválido", async () => {
+		const mockAi = {
+			models: {
+				generateContent: vi.fn().mockResolvedValue({ text: "no-es-json{" }),
+			},
+		} as any;
+
+		const result = await generateStructuredContentWithRetry(
+			mockAi,
+			{},
+			schema,
+			geminiSchema,
+		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error.message).toContain("JSON válido");
+	});
+
+	it("retorna err si el JSON no pasa la validación Zod", async () => {
+		const mockAi = {
+			models: {
+				generateContent: vi
+					.fn()
+					.mockResolvedValue({ text: JSON.stringify({ wrong: 123 }) }),
+			},
+		} as any;
+
+		const result = await generateStructuredContentWithRetry(
+			mockAi,
+			{},
+			schema,
+			geminiSchema,
+		);
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error.message).toContain("Zod");
+	});
+});

--- a/src/utils/embeddings.test.ts
+++ b/src/utils/embeddings.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	cosineSimilarity,
+	findSimilarNotes,
+	generateEmbedding,
+} from "./embeddings";
+
+// Hoisted: mock de @google/genai para el test de error de API
+vi.mock("@google/genai", () => ({
+	GoogleGenAI: vi.fn().mockImplementation(() => ({
+		models: {
+			embedContent: vi.fn().mockRejectedValue(new Error("API error")),
+		},
+	})),
+}));
+
+// --- cosineSimilarity ---
+
+describe("cosineSimilarity", () => {
+	it("vectores idénticos → similitud 1", () => {
+		const v = [1, 2, 3];
+		expect(cosineSimilarity(v, v)).toBeCloseTo(1.0);
+	});
+
+	it("vectores ortogonales → similitud 0", () => {
+		expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0.0);
+	});
+
+	it("vectores opuestos → similitud -1", () => {
+		expect(cosineSimilarity([1, 0], [-1, 0])).toBeCloseTo(-1.0);
+	});
+
+	it("vector cero → devuelve 0 sin dividir por cero", () => {
+		expect(cosineSimilarity([0, 0, 0], [1, 2, 3])).toBe(0);
+	});
+
+	it("vectores de alta dimensión calculan correctamente", () => {
+		const a = Array.from({ length: 768 }, (_, i) => Math.sin(i));
+		const b = Array.from({ length: 768 }, (_, i) => Math.cos(i));
+		const sim = cosineSimilarity(a, b);
+		expect(sim).toBeGreaterThanOrEqual(-1);
+		expect(sim).toBeLessThanOrEqual(1);
+	});
+});
+
+// --- findSimilarNotes ---
+
+describe("findSimilarNotes", () => {
+	const notes = [
+		{ id: "a", embedding: [1, 0, 0] },
+		{ id: "b", embedding: [0, 1, 0] },
+		{ id: "c", embedding: [0.9, 0.1, 0] },
+		{ id: "d" }, // sin embedding
+	];
+
+	it("omite items sin embedding", () => {
+		const results = findSimilarNotes([1, 0, 0], notes, 10);
+		expect(results.map((n) => n.id)).not.toContain("d");
+	});
+
+	it("ordena por similitud descendente", () => {
+		const results = findSimilarNotes([1, 0, 0], notes, 3);
+		// 'a' es idéntico → debe ser el primero
+		expect(results[0].id).toBe("a");
+		// 'c' es más similar a [1,0,0] que 'b'
+		expect(results[1].id).toBe("c");
+	});
+
+	it("respeta el límite de resultados", () => {
+		const results = findSimilarNotes([1, 0, 0], notes, 2);
+		expect(results).toHaveLength(2);
+	});
+
+	it("con lista vacía devuelve array vacío", () => {
+		expect(findSimilarNotes([1, 0, 0], [], 5)).toEqual([]);
+	});
+
+	it("todos sin embedding devuelve array vacío", () => {
+		const noEmbed = [{ id: "x" }, { id: "y" }];
+		expect(findSimilarNotes([1, 0, 0], noEmbed, 5)).toEqual([]);
+	});
+});
+
+// --- generateEmbedding ---
+
+describe("generateEmbedding", () => {
+	it("retorna null si apiKey está vacío", async () => {
+		expect(await generateEmbedding("", "texto")).toBeNull();
+	});
+
+	it("retorna null si el texto está vacío", async () => {
+		expect(await generateEmbedding("api-key", "")).toBeNull();
+	});
+
+	it("retorna null y no lanza si la API falla", async () => {
+		const result = await generateEmbedding("fake-key", "texto de prueba");
+		expect(result).toBeNull();
+	});
+});

--- a/src/utils/nexusCrypto.test.ts
+++ b/src/utils/nexusCrypto.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { decryptData, encryptData } from "./nexusCrypto";
+
+describe("nexusCrypto — AES-256-GCM", () => {
+	it("cifra y descifra texto simple con la misma passphrase", async () => {
+		const plaintext = "mensaje secreto";
+		const passphrase = "clave-de-prueba-32";
+
+		const encrypted = await encryptData(plaintext, passphrase);
+		const decrypted = await decryptData(encrypted, passphrase);
+
+		expect(decrypted).toBe(plaintext);
+	});
+
+	it("produce ciphertext distinto en cada llamada (IV aleatorio)", async () => {
+		const plaintext = "mismo texto";
+		const passphrase = "misma-clave";
+
+		const enc1 = await encryptData(plaintext, passphrase);
+		const enc2 = await encryptData(plaintext, passphrase);
+
+		expect(enc1).not.toBe(enc2);
+	});
+
+	it("falla al descifrar con passphrase incorrecta", async () => {
+		const plaintext = "datos privados";
+		const encrypted = await encryptData(plaintext, "clave-correcta");
+
+		await expect(decryptData(encrypted, "clave-incorrecta")).rejects.toThrow();
+	});
+
+	it("cifra string vacío correctamente", async () => {
+		const encrypted = await encryptData("", "passphrase");
+		const decrypted = await decryptData(encrypted, "passphrase");
+		expect(decrypted).toBe("");
+	});
+
+	it("cifra texto con caracteres especiales y Unicode", async () => {
+		const plaintext = "Notas académicas 📚 — LTI 2026: ñoño";
+		const passphrase = "clave-unicode";
+
+		const encrypted = await encryptData(plaintext, passphrase);
+		const decrypted = await decryptData(encrypted, passphrase);
+
+		expect(decrypted).toBe(plaintext);
+	});
+
+	it("el ciphertext base64 contiene salt (16B) + iv (12B) + datos", async () => {
+		const encrypted = await encryptData("test", "pass");
+		const packed = Uint8Array.from(atob(encrypted), (c) => c.charCodeAt(0));
+		// Mínimo: 16 (salt) + 12 (iv) + 1 (al menos 1 byte de ciphertext + 16 de GCM tag)
+		expect(packed.length).toBeGreaterThanOrEqual(45);
+	});
+});


### PR DESCRIPTION
## Milestone: v3.3.0 — Testing Coverage

Cierra issues #80 #81 #83 #84 #85

## Nuevos archivos de test

| Archivo | Issue | Casos |
|---|---|---|
| `src/utils/aiUtils.test.ts` | #80 | truncateContext, retry 429/5xx/network, Zod validation, empty response |
| `src/utils/nexusCrypto.test.ts` | #81 | AES-256-GCM cifra/descifra, IV aleatorio, passphrase incorrecta, Unicode |
| `src/utils/embeddings.test.ts` | #83 | cosineSimilarity (edge cases), findSimilarNotes (orden, límite), generateEmbedding → null on error |
| `src/domain/progressAnalysis.test.ts` | #85 | calculateProgressStats (vacío/full/invariante), calculateSemesterAverages (decimales, sin grade) |
| `src/store/aetherStore.test.ts` | #84 | CRUD notas, getGraphData Map O(n), findBacklinks |
| `src/store/nexusStore.test.ts` | #84 | CRUD documentos, persistencia localStorage |

## Métricas
- Tests totales: **305 passing** (era 242 antes de v3.3.0) → +63 tests nuevos
- 38 suites pasando
- TypeCheck: limpio

## Test plan
- [x] `npm run test` — 305 tests passing, 1 skipped
- [x] `npx tsc --noEmit` — sin errores
- [x] `npx biome check .` — sin errores en TS/TSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)