### PR TITLE
feat: v3.6.0 P0 — console filtrado, Zod IPC, tests configHandlers

### DIFF
--- a/electron/handlers/configHandlers.test.ts
+++ b/electron/handlers/configHandlers.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	ALLOWED_CONFIG_KEYS,
+	initConfig,
+	makeConfigHandlers,
+} from "./configHandlers";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeStore(initial: Record<string, string> = {}) {
+	const data: Record<string, string> = { ...initial };
+	return {
+		set: vi.fn((key: string, value: string) => {
+			data[key] = value;
+		}),
+		get: vi.fn((key: string) => data[key]),
+		_data: data,
+	};
+}
+
+const VALID_KEY = "gemini_api_key";
+const INVALID_KEY = "not_a_real_key";
+
+// ── makeConfigHandlers ────────────────────────────────────────────────────────
+
+describe("makeConfigHandlers", () => {
+	describe("configSet", () => {
+		it("guarda el valor cuando la clave está en la allowlist", () => {
+			const store = makeStore();
+			const h = makeConfigHandlers(store);
+			h.configSet(VALID_KEY, "abc123");
+			expect(store.set).toHaveBeenCalledWith(VALID_KEY, "abc123");
+		});
+
+		it("lanza error si la clave no está en la allowlist", () => {
+			const store = makeStore();
+			const h = makeConfigHandlers(store);
+			expect(() => h.configSet(INVALID_KEY, "x")).toThrow(/clave no permitida/);
+			expect(store.set).not.toHaveBeenCalled();
+		});
+
+		it("acepta todas las claves definidas en ALLOWED_CONFIG_KEYS", () => {
+			const store = makeStore();
+			const h = makeConfigHandlers(store);
+			for (const key of ALLOWED_CONFIG_KEYS) {
+				expect(() => h.configSet(key, "val")).not.toThrow();
+			}
+		});
+	});
+
+	describe("configGet", () => {
+		it("devuelve el valor almacenado para una clave válida", () => {
+			const store = makeStore({ [VALID_KEY]: "stored_value" });
+			const h = makeConfigHandlers(store);
+			expect(h.configGet(VALID_KEY)).toBe("stored_value");
+		});
+
+		it("devuelve null si la clave válida no tiene valor", () => {
+			const store = makeStore();
+			const h = makeConfigHandlers(store);
+			expect(h.configGet(VALID_KEY)).toBeNull();
+		});
+
+		it("lanza error si la clave no está en la allowlist", () => {
+			const store = makeStore();
+			const h = makeConfigHandlers(store);
+			expect(() => h.configGet(INVALID_KEY)).toThrow(/clave no permitida/);
+			expect(store.get).not.toHaveBeenCalled();
+		});
+	});
+});
+
+// ── initConfig con validación Zod ─────────────────────────────────────────────
+
+describe("initConfig", () => {
+	function makeIpcMain() {
+		const handlers: Record<string, (...args: unknown[]) => unknown> = {};
+		return {
+			handle: vi.fn((channel: string, fn: (...args: unknown[]) => unknown) => {
+				handlers[channel] = fn;
+			}),
+			_call: (channel: string, ...args: unknown[]) =>
+				handlers[channel]?.(...args),
+		};
+	}
+
+	it("registra los canales config:set y config:get", () => {
+		const store = makeStore();
+		const ipc = makeIpcMain();
+		initConfig(store, ipc);
+		expect(ipc.handle).toHaveBeenCalledWith("config:set", expect.any(Function));
+		expect(ipc.handle).toHaveBeenCalledWith("config:get", expect.any(Function));
+	});
+
+	it("config:set invoca store.set con tipos válidos", () => {
+		const store = makeStore();
+		const ipc = makeIpcMain();
+		initConfig(store, ipc);
+		ipc._call("config:set", null, VALID_KEY, "api_value");
+		expect(store.set).toHaveBeenCalledWith(VALID_KEY, "api_value");
+	});
+
+	it("config:set lanza ZodError si el tipo de clave no es string", () => {
+		const store = makeStore();
+		const ipc = makeIpcMain();
+		initConfig(store, ipc);
+		expect(() => ipc._call("config:set", null, 42, "val")).toThrow();
+		expect(store.set).not.toHaveBeenCalled();
+	});
+
+	it("config:set lanza ZodError si la clave es string vacío", () => {
+		const store = makeStore();
+		const ipc = makeIpcMain();
+		initConfig(store, ipc);
+		expect(() => ipc._call("config:set", null, "", "val")).toThrow();
+	});
+
+	it("config:get devuelve valor correcto con tipos válidos", () => {
+		const store = makeStore({ [VALID_KEY]: "secret" });
+		const ipc = makeIpcMain();
+		initConfig(store, ipc);
+		expect(ipc._call("config:get", null, VALID_KEY)).toBe("secret");
+	});
+
+	it("config:get lanza ZodError si el tipo de clave no es string", () => {
+		const store = makeStore();
+		const ipc = makeIpcMain();
+		initConfig(store, ipc);
+		expect(() => ipc._call("config:get", null, null)).toThrow();
+	});
+});

--- a/electron/handlers/configHandlers.ts
+++ b/electron/handlers/configHandlers.ts
@@ -9,6 +9,17 @@
  *   initConfig(store);   // registra config:set y config:get en ipcMain
  */
 
+import { z } from "zod";
+
+const ConfigSetSchema = z.object({
+	key: z.string().min(1),
+	value: z.string(),
+});
+
+const ConfigGetSchema = z.object({
+	key: z.string().min(1),
+});
+
 export interface ConfigStore {
 	set(key: string, value: string): void;
 	get(key: string): string | undefined;
@@ -36,12 +47,17 @@ export function initConfig(
 	},
 ): void {
 	const handlers = makeConfigHandlers(store);
-	ipcMain.handle("config:set", ((...args: unknown[]) =>
-		handlers.configSet(args[1] as string, args[2] as string)) as (
-		...args: unknown[]
-	) => unknown);
-	ipcMain.handle("config:get", ((...args: unknown[]) =>
-		handlers.configGet(args[1] as string)) as (...args: unknown[]) => unknown);
+	ipcMain.handle("config:set", ((...args: unknown[]) => {
+		const { key, value } = ConfigSetSchema.parse({
+			key: args[1],
+			value: args[2],
+		});
+		return handlers.configSet(key, value);
+	}) as (...args: unknown[]) => unknown);
+	ipcMain.handle("config:get", ((...args: unknown[]) => {
+		const { key } = ConfigGetSchema.parse({ key: args[1] });
+		return handlers.configGet(key);
+	}) as (...args: unknown[]) => unknown);
 }
 
 export function makeConfigHandlers(store: ConfigStore): ConfigHandlers {

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -119,7 +119,7 @@ describe("ErrorBoundary", () => {
 				</ErrorBoundary>,
 			);
 			expect(consoleError).toHaveBeenCalledWith(
-				"[ErrorBoundary]",
+				expect.stringContaining("ErrorBoundary"),
 				expect.any(Error),
 				expect.anything(),
 			);

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import React from "react";
+import { logger } from "../utils/logger";
 
 interface ErrorBoundaryProps {
 	children: React.ReactNode;
@@ -28,11 +29,8 @@ export class ErrorBoundary extends React.Component<
 	}
 
 	componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-		console.error(
-			`[ErrorBoundary${this.props.section ? ` — ${this.props.section}` : ""}]`,
-			error,
-			errorInfo,
-		);
+		const section = this.props.section ? ` — ${this.props.section}` : "";
+		logger.error("ErrorBoundary" + section, error.message, error, errorInfo);
 	}
 
 	handleReset = () => {

--- a/src/hooks/useSubjectData.tsx
+++ b/src/hooks/useSubjectData.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { CURRICULUM, type Subject, type SubjectStatus } from "../data/lti";
+import { logger } from "../utils/logger";
 import { safeParseJSON } from "../utils/safeStorage";
 
 export interface SubjectResource {
@@ -70,7 +71,7 @@ export function SubjectDataProvider({
 
 			// --- Event-Driven Trigger (Eje 2.2) ---
 			if (partialData.status === "en_curso" && existing.status !== "en_curso") {
-				console.log(`[ORCHESTRATOR] Activating subject: ${subject.name}`);
+				logger.info("Orchestrator", `Activating subject: ${subject.name}`);
 				// Side-effect: Ensure resources directory exists (simulated)
 				if (newData.resources.length === 0) {
 					newData.resources = [
@@ -113,8 +114,9 @@ export function SubjectDataProvider({
 		// Instead of deleting data, we move it to an 'archived' state if it has content
 		setData((prev) => {
 			if (!prev[id]) return prev;
-			console.log(
-				`[ORCHESTRATOR] Soft Delete: Archiving data for subject ${id}`,
+			logger.info(
+				"Orchestrator",
+				`Soft Delete: Archiving data for subject ${id}`,
 			);
 			const archivedData = {
 				...prev[id],

--- a/src/pages/AetherChat.tsx
+++ b/src/pages/AetherChat.tsx
@@ -5,6 +5,7 @@ import { ChatInputArea } from "../components/chat/ChatInputArea";
 import { ChatSkeleton } from "../components/chat/ChatSkeleton";
 import { apiBackend } from "../services/aiClient";
 import { useAetherStore } from "../store/aetherStore";
+import { logger } from "../utils/logger";
 import {
 	failure,
 	isLoading,
@@ -92,7 +93,7 @@ export default function AetherChat() {
 
 			setStatus(success(undefined));
 		} catch (error: any) {
-			console.error("Gemini API Error:", error);
+			logger.error("AetherChat", "Gemini API Error", error);
 			addChatMessage({
 				role: "model",
 				text: `**Error de Conexión:** ${error.message || "No se pudo contactar con Gemini. Revisa tu API Key o conexión al servicio."}`,


### PR DESCRIPTION
## Issues resueltos

- Closes #145
- Closes #147
- Closes #148

## Cambios

### #145 — `console.*` reemplazados con `logger.*`
- `ErrorBoundary.tsx`: `componentDidCatch` usa `logger.error` → filtrado por nivel de entorno
- `AetherChat.tsx`: catch de Gemini API usa `logger.error`
- `useSubjectData.tsx`: dos `console.log` de orchestrator usan `logger.info`
- `ErrorBoundary.test.tsx`: expectativa actualizada a la firma del logger

### #147 — Tests para `configHandlers.ts`
- Nuevo archivo `electron/handlers/configHandlers.test.ts` con **12 tests**
- Cubre `makeConfigHandlers` (set/get con claves válidas e inválidas, todas las claves de la allowlist)
- Cubre `initConfig` (registro de canales, Zod válido/inválido)

### #148 — Validación Zod en handlers IPC
- `initConfig` parsea `args[1]` y `args[2]` con `ConfigSetSchema`/`ConfigGetSchema` (Zod)
- Lanza `ZodError` si el renderer envía tipos incorrectos o string vacío

## Test plan
- [ ] CI verde en las 3 plataformas (ubuntu/windows/macos, node 22+24)
- [ ] `npx vitest run` local: 56 archivos, 589 tests ✅
- [ ] `npx biome check`: 0 errores, 4 warnings pre-existentes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)