### PR TITLE
feat(v3.8.0-p3): arquitectura stores, CSP docs y refactor GmailWidget

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -268,6 +268,26 @@ function initObserver(): void {
 // ── CSP via main process — Issue #175 ─────────────────────────────────────────
 // El meta tag CSP en index.html es ignorado por Electron en rutas file://.
 // La única forma garantizada de aplicar CSP en Electron es vía onHeadersReceived.
+//
+// SC-07 (#239): ¿Por qué unsafe-inline?
+// Vite en producción emite <script type="module"> externos (no inline), pero el
+// build también genera estilos inline para animaciones CSS-in-JS y módulos
+// lazy-loaded (BlockNote, Framer Motion). En Electron con file:// no existe un
+// servidor origin que permita usar hashes ('sha256-...'): el hash del HTML
+// cambia en cada build y el proceso de signing lo hace impredecible.
+// Implementar nonces requeriría generar un token en el proceso principal y
+// pasarlo al renderer ANTES de servir el HTML, lo cual no es posible con el
+// enfoque file:// + BrowserWindow.loadFile() actual.
+//
+// Mitigaciones compensatorias (en lugar de nonces):
+//   1. nodeIntegration: false  — el renderer no tiene acceso a Node.js
+//   2. contextIsolation: true  — preload corre en contexto separado del renderer
+//   3. sandbox: true           — el renderer está en el sandbox de Chromium
+//   4. object-src 'none'       — bloquea plugins Flash / objeto embebido
+//   5. frame-src 'none'        — sin iframes (reduce superficie XSS)
+//   6. connect-src allowlist   — solo dominios de Google API autorizados
+// La combinación de sandbox + contextIsolation elimina el vector de escalada
+// de privilegios incluso si un atacante logra ejecutar JS en el renderer.
 function setupCSP(): void {
 	session.defaultSession.webRequest.onHeadersReceived(
 		{ urls: ["<all_urls>"] },
@@ -278,7 +298,7 @@ function setupCSP(): void {
 					"Content-Security-Policy": [
 						[
 							"default-src 'self'",
-							"script-src 'self' 'unsafe-inline'", // unsafe-inline requerido por Vite chunks
+							"script-src 'self' 'unsafe-inline'", // ver comentario SC-07 (#239) arriba
 							"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
 							"font-src 'self' data: https://fonts.gstatic.com",
 							"img-src 'self' data: https:",

--- a/src/components/dashboard/GmailInbox.tsx
+++ b/src/components/dashboard/GmailInbox.tsx
@@ -1,0 +1,154 @@
+import { motion } from "framer-motion";
+import {
+	AlertCircle,
+	ExternalLink,
+	LogIn,
+	Mail,
+	Minus,
+	RefreshCw,
+	Settings,
+} from "lucide-react";
+import type { GmailMessage } from "../../services/gmail";
+
+interface GmailInboxProps {
+	messages: GmailMessage[];
+	loading: boolean;
+	error: string | null;
+	isAuthenticated: boolean;
+	onLogin: () => void;
+	onRefresh: () => void;
+	onSignOut: () => void;
+	onSettingsOpen: () => void;
+	onMinimize: () => void;
+}
+
+export function GmailInbox({
+	messages,
+	loading,
+	error,
+	isAuthenticated,
+	onLogin,
+	onRefresh,
+	onSignOut,
+	onSettingsOpen,
+	onMinimize,
+}: GmailInboxProps) {
+	return (
+		<motion.div
+			layoutId="gmail-widget"
+			className="fixed bottom-6 right-6 w-80 h-[400px] z-[100] card p-5 border-t-2 border-lti-blue shadow-2xl bg-navy-950 flex flex-col"
+		>
+			<div className="flex items-center justify-between mb-4">
+				<div className="flex items-center gap-2">
+					<div className="p-1.5 bg-lti-blue/10 rounded-lg">
+						<Mail size={16} className="text-lti-blue" />
+					</div>
+					<h2 className="text-white font-semibold text-sm">Bandeja Gmail</h2>
+				</div>
+				<div className="flex items-center gap-1">
+					{isAuthenticated && (
+						<button
+							onClick={onRefresh}
+							disabled={loading}
+							className="p-1.5 text-slate-400 hover:text-white hover:bg-navy-800 rounded-md transition-all"
+						>
+							<RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+						</button>
+					)}
+					<button
+						onClick={onSettingsOpen}
+						className="p-1.5 text-slate-400 hover:text-white hover:bg-navy-800 rounded-md transition-all"
+					>
+						<Settings size={14} />
+					</button>
+					<button
+						onClick={onMinimize}
+						className="p-1.5 text-slate-400 hover:text-white hover:bg-navy-800 rounded-md transition-all"
+					>
+						<Minus size={14} />
+					</button>
+				</div>
+			</div>
+
+			<div className="flex-1 flex flex-col overflow-hidden">
+				{!isAuthenticated ? (
+					<div className="flex-1 flex flex-col items-center justify-center text-center p-4 space-y-4">
+						<LogIn size={24} className="text-slate-600 mb-2" />
+						<p className="text-xs text-slate-500">
+							Conecta tu cuenta para monitorear correos.
+						</p>
+						<button
+							onClick={onLogin}
+							className="px-4 py-2 bg-white text-navy-950 text-xs font-bold rounded-lg hover:bg-slate-200 transition-colors"
+						>
+							Iniciar Sesión
+						</button>
+					</div>
+				) : error ? (
+					<div className="flex-1 flex flex-col items-center justify-center text-center p-4 space-y-3">
+						<AlertCircle size={24} className="text-lti-coral" />
+						<p className="text-xs text-slate-500 italic">{error}</p>
+					</div>
+				) : messages.length === 0 && !loading ? (
+					<div className="flex-1 flex flex-col items-center justify-center text-center p-4 opacity-40">
+						<Mail size={32} className="text-slate-600 mb-2" />
+						<p className="text-xs text-slate-500 font-medium tracking-wide uppercase">
+							Todo al día
+						</p>
+					</div>
+				) : (
+					<div className="space-y-2 overflow-y-auto pr-1 custom-scrollbar">
+						{messages.map((msg) => (
+							<a
+								key={msg.id}
+								href={`https://mail.google.com/mail/u/0/#inbox/${msg.threadId}`}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="group block p-2.5 rounded-lg bg-navy-900/40 border border-navy-700/30 hover:border-lti-blue/30 hover:bg-navy-900/60 transition-all"
+							>
+								<div className="flex justify-between items-start gap-2 mb-1">
+									<p className="text-xs font-bold text-slate-200 truncate group-hover:text-lti-blue transition-colors">
+										{msg.from?.split("<")[0].trim()}
+									</p>
+									<p className="text-[10px] text-slate-500 whitespace-nowrap">
+										{msg.date
+											? new Date(msg.date).toLocaleDateString([], {
+													month: "short",
+													day: "numeric",
+												})
+											: ""}
+									</p>
+								</div>
+								<h3 className="text-[11px] font-semibold text-white line-clamp-1 mb-0.5">
+									{msg.subject}
+								</h3>
+								<p className="text-[10px] text-slate-500 line-clamp-2 leading-relaxed italic">
+									{msg.snippet}
+								</p>
+							</a>
+						))}
+					</div>
+				)}
+			</div>
+
+			{isAuthenticated && (
+				<div className="pt-4 mt-auto border-t border-navy-800 flex items-center justify-between">
+					<a
+						href="https://mail.google.com"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="text-[10px] text-lti-blue font-bold flex items-center gap-1 hover:underline"
+					>
+						ABRIR EN GMAIL <ExternalLink size={10} />
+					</a>
+					<button
+						onClick={onSignOut}
+						className="text-[10px] text-slate-400 hover:text-lti-coral transition-colors"
+					>
+						Salir
+					</button>
+				</div>
+			)}
+		</motion.div>
+	);
+}

--- a/src/components/dashboard/GmailMinimized.tsx
+++ b/src/components/dashboard/GmailMinimized.tsx
@@ -1,0 +1,41 @@
+import { motion } from "framer-motion";
+import { Mail } from "lucide-react";
+
+interface GmailMinimizedProps {
+	isSilent: boolean;
+	messageCount: number;
+	onExpand: () => void;
+	onConfigOpen: () => void;
+}
+
+export function GmailMinimized({
+	isSilent,
+	messageCount,
+	onExpand,
+	onConfigOpen,
+}: GmailMinimizedProps) {
+	return (
+		<motion.button
+			layoutId="gmail-widget"
+			onClick={() => (isSilent ? onConfigOpen() : onExpand())}
+			className={`fixed bottom-6 right-6 z-[100] w-12 h-12 rounded-full shadow-lg flex items-center justify-center text-white hover:scale-110 transition-transform active:scale-95 group ${
+				isSilent
+					? "bg-slate-800 opacity-60 border border-slate-700"
+					: "bg-lti-blue"
+			}`}
+		>
+			<Mail size={20} className={isSilent ? "text-slate-400" : "text-white"} />
+			{messageCount > 0 && !isSilent && (
+				<span className="absolute -top-1 -right-1 w-5 h-5 bg-lti-coral text-[10px] font-bold rounded-full flex items-center justify-center border-2 border-navy-950">
+					{messageCount}
+				</span>
+			)}
+			{/* Tooltip on hover */}
+			<span className="absolute right-14 bg-navy-800 text-white text-[10px] py-1 px-2 rounded opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity whitespace-nowrap border border-navy-700">
+				{isSilent
+					? "Conectividad Potencial (Configura Gmail)"
+					: `${messageCount} correos nuevos`}
+			</span>
+		</motion.button>
+	);
+}

--- a/src/components/dashboard/GmailSettingsPanel.tsx
+++ b/src/components/dashboard/GmailSettingsPanel.tsx
@@ -1,0 +1,98 @@
+import { AnimatePresence, motion } from "framer-motion";
+import { ExternalLink, Settings } from "lucide-react";
+import { AssistantGuide } from "../AssistantGuide";
+
+interface GmailSettingsPanelProps {
+	gmailClientId: string;
+	gmailApiKey: string;
+	onClientIdChange: (v: string) => void;
+	onApiKeyChange: (v: string) => void;
+	onClose: () => void;
+	showGuide: boolean;
+	onShowGuide: () => void;
+	onCloseGuide: () => void;
+}
+
+export function GmailSettingsPanel({
+	gmailClientId,
+	gmailApiKey,
+	onClientIdChange,
+	onApiKeyChange,
+	onClose,
+	showGuide,
+	onShowGuide,
+	onCloseGuide,
+}: GmailSettingsPanelProps) {
+	return (
+		<>
+			<motion.div
+				layout
+				className="fixed bottom-6 right-6 w-80 z-[100] card p-5 border-t-2 border-lti-coral shadow-2xl bg-navy-950"
+			>
+				<div className="flex items-center justify-between mb-4">
+					<h2 className="text-white font-semibold text-sm flex items-center gap-2">
+						<Settings size={16} className="text-lti-coral" />
+						Configurar Gmail
+					</h2>
+					<button
+						onClick={onClose}
+						className="text-xs text-slate-400 hover:text-white"
+					>
+						Cerrar
+					</button>
+				</div>
+				<div className="space-y-4">
+					<div className="bg-navy-900/50 p-3 rounded-lg border border-navy-800 space-y-2">
+						<p className="text-[10px] text-slate-400 leading-tight">
+							¿No tienes credenciales? Sigue nuestra guía paso a paso.
+						</p>
+						<button
+							onClick={onShowGuide}
+							className="w-full py-1.5 bg-navy-800 text-lti-blue text-[10px] font-bold rounded-md hover:bg-navy-700 transition-colors flex items-center justify-center gap-2"
+						>
+							Inicia la Guía de Configuración <ExternalLink size={10} />
+						</button>
+					</div>
+
+					<div className="space-y-3">
+						<div>
+							<label className="block text-[10px] font-medium text-slate-500 uppercase mb-1">
+								Client ID
+							</label>
+							<input
+								type="text"
+								value={gmailClientId || ""}
+								onChange={(e) => onClientIdChange(e.target.value)}
+								className="w-full bg-navy-900 border border-navy-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-lti-blue"
+								placeholder="000.apps.googleusercontent.com"
+							/>
+						</div>
+						<div>
+							<label className="block text-[10px] font-medium text-slate-500 uppercase mb-1">
+								API Key
+							</label>
+							<input
+								type="password"
+								value={gmailApiKey || ""}
+								onChange={(e) => onApiKeyChange(e.target.value)}
+								className="w-full bg-navy-900 border border-navy-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-lti-blue"
+								placeholder="AIza..."
+							/>
+						</div>
+					</div>
+					<button
+						onClick={onClose}
+						disabled={!gmailClientId || !gmailApiKey}
+						className="w-full py-2 bg-lti-blue text-white text-xs font-bold rounded-lg transition-colors border-none cursor-pointer"
+					>
+						Guardar y Cerrar
+					</button>
+				</div>
+			</motion.div>
+
+			<AnimatePresence>
+				{showGuide && <AssistantGuide onClose={onCloseGuide} />}
+			</AnimatePresence>
+		</>
+	);
+}

--- a/src/components/dashboard/GmailWidget.test.tsx
+++ b/src/components/dashboard/GmailWidget.test.tsx
@@ -12,8 +12,8 @@ vi.mock("../../services/gmail", () => ({
 	},
 }));
 
-vi.mock("../../store/aetherStore", () => ({
-	useAetherStore: vi.fn(),
+vi.mock("../../store/userConfigStore", () => ({
+	useUserConfigStore: vi.fn(),
 }));
 
 // framer-motion puede necesitar stub mínimo en jsdom
@@ -31,7 +31,7 @@ vi.mock("framer-motion", () => ({
 
 import { gmailService } from "../../services/gmail";
 // Importar después de los mocks
-import { useAetherStore } from "../../store/aetherStore";
+import { useUserConfigStore } from "../../store/userConfigStore";
 import { GmailWidget } from "./GmailWidget";
 
 function setupStore({
@@ -41,7 +41,7 @@ function setupStore({
 	gmailClientId?: string;
 	gmailApiKey?: string;
 } = {}) {
-	vi.mocked(useAetherStore).mockReturnValue({
+	vi.mocked(useUserConfigStore).mockReturnValue({
 		gmailClientId,
 		gmailApiKey,
 		setGmailClientId: vi.fn(),

--- a/src/components/dashboard/GmailWidget.tsx
+++ b/src/components/dashboard/GmailWidget.tsx
@@ -1,22 +1,14 @@
-import { AnimatePresence, motion } from "framer-motion";
-import {
-	AlertCircle,
-	ExternalLink,
-	LogIn,
-	Mail,
-	Minus,
-	RefreshCw,
-	Settings,
-} from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { type GmailMessage, gmailService } from "../../services/gmail";
-import { useAetherStore } from "../../store/aetherStore";
+import { useUserConfigStore } from "../../store/userConfigStore";
 import { logger } from "../../utils/logger";
-import { AssistantGuide } from "../AssistantGuide";
+import { GmailInbox } from "./GmailInbox";
+import { GmailMinimized } from "./GmailMinimized";
+import { GmailSettingsPanel } from "./GmailSettingsPanel";
 
 export function GmailWidget() {
 	const { gmailClientId, gmailApiKey, setGmailClientId, setGmailApiKey } =
-		useAetherStore();
+		useUserConfigStore();
 	const [messages, setMessages] = useState<GmailMessage[]>([]);
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -85,76 +77,16 @@ export function GmailWidget() {
 	// --- Render Settings Only if explicit ---
 	if (showSettings && (!gmailClientId || !gmailApiKey)) {
 		return (
-			<>
-				<motion.div
-					layout
-					className="fixed bottom-6 right-6 w-80 z-[100] card p-5 border-t-2 border-lti-coral shadow-2xl bg-navy-950"
-				>
-					<div className="flex items-center justify-between mb-4">
-						<h2 className="text-white font-semibold text-sm flex items-center gap-2">
-							<Settings size={16} className="text-lti-coral" />
-							Configurar Gmail
-						</h2>
-						<button
-							onClick={() => setShowSettings(false)}
-							className="text-xs text-slate-400 hover:text-white"
-						>
-							Cerrar
-						</button>
-					</div>
-					<div className="space-y-4">
-						<div className="bg-navy-900/50 p-3 rounded-lg border border-navy-800 space-y-2">
-							<p className="text-[10px] text-slate-400 leading-tight">
-								¿No tienes credenciales? Sigue nuestra guía paso a paso.
-							</p>
-							<button
-								onClick={() => setShowGuide(true)}
-								className="w-full py-1.5 bg-navy-800 text-lti-blue text-[10px] font-bold rounded-md hover:bg-navy-700 transition-colors flex items-center justify-center gap-2"
-							>
-								Inicia la Guía de Configuración <ExternalLink size={10} />
-							</button>
-						</div>
-
-						<div className="space-y-3">
-							<div>
-								<label className="block text-[10px] font-medium text-slate-500 uppercase mb-1">
-									Client ID
-								</label>
-								<input
-									type="text"
-									value={gmailClientId || ""}
-									onChange={(e) => setGmailClientId(e.target.value)}
-									className="w-full bg-navy-900 border border-navy-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-lti-blue"
-									placeholder="000.apps.googleusercontent.com"
-								/>
-							</div>
-							<div>
-								<label className="block text-[10px] font-medium text-slate-500 uppercase mb-1">
-									API Key
-								</label>
-								<input
-									type="password"
-									value={gmailApiKey || ""}
-									onChange={(e) => setGmailApiKey(e.target.value)}
-									className="w-full bg-navy-900 border border-navy-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-lti-blue"
-									placeholder="AIza..."
-								/>
-							</div>
-						</div>
-						<button
-							onClick={() => setShowSettings(false)}
-							disabled={!gmailClientId || !gmailApiKey}
-							className="w-full py-2 bg-lti-blue text-white text-xs font-bold rounded-lg transition-colors border-none cursor-pointer"
-						>
-							Guardar y Cerrar
-						</button>
-					</div>
-				</motion.div>
-
-				<AnimatePresence>
-					{showGuide && <AssistantGuide onClose={() => setShowGuide(false)} />}
-				</AnimatePresence>
-			</>
+			<GmailSettingsPanel
+				gmailClientId={gmailClientId ?? ""}
+				gmailApiKey={gmailApiKey ?? ""}
+				onClientIdChange={setGmailClientId}
+				onApiKeyChange={setGmailApiKey}
+				onClose={() => setShowSettings(false)}
+				showGuide={showGuide}
+				onShowGuide={() => setShowGuide(true)}
+				onCloseGuide={() => setShowGuide(false)}
+			/>
 		);
 	}
 
@@ -162,153 +94,27 @@ export function GmailWidget() {
 	if (isMinimized || !gmailClientId || !gmailApiKey) {
 		const isSilent = !gmailClientId || !gmailApiKey;
 		return (
-			<motion.button
-				layoutId="gmail-widget"
-				onClick={() =>
-					isSilent ? setShowSettings(true) : setIsMinimized(false)
-				}
-				className={`fixed bottom-6 right-6 z-[100] w-12 h-12 rounded-full shadow-lg flex items-center justify-center text-white hover:scale-110 transition-transform active:scale-95 group ${
-					isSilent
-						? "bg-slate-800 opacity-60 border border-slate-700"
-						: "bg-lti-blue"
-				}`}
-			>
-				<Mail
-					size={20}
-					className={isSilent ? "text-slate-400" : "text-white"}
-				/>
-				{messages.length > 0 && !isSilent && (
-					<span className="absolute -top-1 -right-1 w-5 h-5 bg-lti-coral text-[10px] font-bold rounded-full flex items-center justify-center border-2 border-navy-950">
-						{messages.length}
-					</span>
-				)}
-				{/* Tooltip on hover */}
-				<span className="absolute right-14 bg-navy-800 text-white text-[10px] py-1 px-2 rounded opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity whitespace-nowrap border border-navy-700">
-					{isSilent
-						? "Conectividad Potencial (Configura Gmail)"
-						: `${messages.length} correos nuevos`}
-				</span>
-			</motion.button>
+			<GmailMinimized
+				isSilent={isSilent}
+				messageCount={messages.length}
+				onExpand={() => setIsMinimized(false)}
+				onConfigOpen={() => setShowSettings(true)}
+			/>
 		);
 	}
 
 	// --- Render Full Window ---
 	return (
-		<motion.div
-			layoutId="gmail-widget"
-			className="fixed bottom-6 right-6 w-80 h-[400px] z-[100] card p-5 border-t-2 border-lti-blue shadow-2xl bg-navy-950 flex flex-col"
-		>
-			<div className="flex items-center justify-between mb-4">
-				<div className="flex items-center gap-2">
-					<div className="p-1.5 bg-lti-blue/10 rounded-lg">
-						<Mail size={16} className="text-lti-blue" />
-					</div>
-					<h2 className="text-white font-semibold text-sm">Bandeja Gmail</h2>
-				</div>
-				<div className="flex items-center gap-1">
-					{isAuthenticated && (
-						<button
-							onClick={fetchEmails}
-							disabled={loading}
-							className="p-1.5 text-slate-400 hover:text-white hover:bg-navy-800 rounded-md transition-all"
-						>
-							<RefreshCw size={14} className={loading ? "animate-spin" : ""} />
-						</button>
-					)}
-					<button
-						onClick={() => setShowSettings(true)}
-						className="p-1.5 text-slate-400 hover:text-white hover:bg-navy-800 rounded-md transition-all"
-					>
-						<Settings size={14} />
-					</button>
-					<button
-						onClick={() => setIsMinimized(true)}
-						className="p-1.5 text-slate-400 hover:text-white hover:bg-navy-800 rounded-md transition-all"
-					>
-						<Minus size={14} />
-					</button>
-				</div>
-			</div>
-
-			<div className="flex-1 flex flex-col overflow-hidden">
-				{!isAuthenticated ? (
-					<div className="flex-1 flex flex-col items-center justify-center text-center p-4 space-y-4">
-						<LogIn size={24} className="text-slate-600 mb-2" />
-						<p className="text-xs text-slate-500">
-							Conecta tu cuenta para monitorear correos.
-						</p>
-						<button
-							onClick={handleLogin}
-							className="px-4 py-2 bg-white text-navy-950 text-xs font-bold rounded-lg hover:bg-slate-200 transition-colors"
-						>
-							Iniciar Sesión
-						</button>
-					</div>
-				) : error ? (
-					<div className="flex-1 flex flex-col items-center justify-center text-center p-4 space-y-3">
-						<AlertCircle size={24} className="text-lti-coral" />
-						<p className="text-xs text-slate-500 italic">{error}</p>
-					</div>
-				) : messages.length === 0 && !loading ? (
-					<div className="flex-1 flex flex-col items-center justify-center text-center p-4 opacity-40">
-						<Mail size={32} className="text-slate-600 mb-2" />
-						<p className="text-xs text-slate-500 font-medium tracking-wide uppercase">
-							Todo al día
-						</p>
-					</div>
-				) : (
-					<div className="space-y-2 overflow-y-auto pr-1 custom-scrollbar">
-						{messages.map((msg) => (
-							<a
-								key={msg.id}
-								href={`https://mail.google.com/mail/u/0/#inbox/${msg.threadId}`}
-								target="_blank"
-								rel="noopener noreferrer"
-								className="group block p-2.5 rounded-lg bg-navy-900/40 border border-navy-700/30 hover:border-lti-blue/30 hover:bg-navy-900/60 transition-all"
-							>
-								<div className="flex justify-between items-start gap-2 mb-1">
-									<p className="text-xs font-bold text-slate-200 truncate group-hover:text-lti-blue transition-colors">
-										{msg.from?.split("<")[0].trim()}
-									</p>
-									<p className="text-[10px] text-slate-500 whitespace-nowrap">
-										{msg.date
-											? new Date(msg.date).toLocaleDateString([], {
-													month: "short",
-													day: "numeric",
-												})
-											: ""}
-									</p>
-								</div>
-								<h3 className="text-[11px] font-semibold text-white line-clamp-1 mb-0.5">
-									{msg.subject}
-								</h3>
-								<p className="text-[10px] text-slate-500 line-clamp-2 leading-relaxed italic">
-									{msg.snippet}
-								</p>
-							</a>
-						))}
-					</div>
-				)}
-			</div>
-
-			{isAuthenticated && (
-				<div className="pt-4 mt-auto border-t border-navy-800 flex items-center justify-between">
-					<a
-						href="https://mail.google.com"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="text-[10px] text-lti-blue font-bold flex items-center gap-1 hover:underline"
-					>
-						ABRIR EN GMAIL <ExternalLink size={10} />
-					</a>
-					<button
-						onClick={handleSignOut}
-						className="text-[10px] text-slate-400 hover:text-lti-coral transition-colors"
-					>
-						Salir
-					</button>
-				</div>
-			)}
-		</motion.div>
+		<GmailInbox
+			messages={messages}
+			loading={loading}
+			error={error}
+			isAuthenticated={isAuthenticated}
+			onLogin={handleLogin}
+			onRefresh={fetchEmails}
+			onSignOut={handleSignOut}
+			onSettingsOpen={() => setShowSettings(true)}
+			onMinimize={() => setIsMinimized(true)}
+		/>
 	);
 }

--- a/src/hooks/useCloudSync.test.ts
+++ b/src/hooks/useCloudSync.test.ts
@@ -39,17 +39,22 @@ vi.mock("../store/aetherStore", () => ({
 	useAetherStore: Object.assign(
 		() => ({
 			notes: [],
-			geminiApiKey: "",
-			gmailClientId: "",
-			gmailApiKey: "",
-			setGeminiApiKey: mockSetGeminiApiKey,
-			setGmailClientId: mockSetGmailClientId,
-			setGmailApiKey: mockSetGmailApiKey,
 		}),
 		{
 			setState: mockAetherSetState,
 		},
 	),
+}));
+
+vi.mock("../store/userConfigStore", () => ({
+	useUserConfigStore: () => ({
+		geminiApiKey: "",
+		gmailClientId: "",
+		gmailApiKey: "",
+		setGeminiApiKey: mockSetGeminiApiKey,
+		setGmailClientId: mockSetGmailClientId,
+		setGmailApiKey: mockSetGmailApiKey,
+	}),
 }));
 
 vi.mock("../store/nexusStore", () => ({

--- a/src/hooks/useCloudSync.ts
+++ b/src/hooks/useCloudSync.ts
@@ -4,6 +4,7 @@ import type { ScheduleItem } from "../pages/Horarios";
 import type { Task } from "../pages/Tareas";
 import { useAetherStore } from "../store/aetherStore";
 import { useNexusStore } from "../store/nexusStore";
+import { useUserConfigStore } from "../store/userConfigStore";
 import { type AppData, authService, syncService } from "../utils/firebase";
 import { logger } from "../utils/logger";
 import { AppDataSchema, type CalendarEventsMap } from "../utils/schemas";
@@ -35,15 +36,15 @@ export function useCloudSync(
 		};
 	}, []);
 
+	const { notes: aetherNotes } = useAetherStore();
 	const {
-		notes: aetherNotes,
 		geminiApiKey,
 		setGeminiApiKey,
 		gmailClientId,
 		gmailApiKey,
 		setGmailClientId,
 		setGmailApiKey,
-	} = useAetherStore();
+	} = useUserConfigStore();
 	const { documents: nexusDocs } = useNexusStore();
 
 	// Inicializar auth usando el servicio desacoplado

--- a/src/pages/AetherChat.tsx
+++ b/src/pages/AetherChat.tsx
@@ -5,6 +5,7 @@ import { ChatInputArea } from "../components/chat/ChatInputArea";
 import { ChatSkeleton } from "../components/chat/ChatSkeleton";
 import { apiBackend } from "../services/aiClient";
 import { useAetherStore } from "../store/aetherStore";
+import { useUserConfigStore } from "../store/userConfigStore";
 import { logger } from "../utils/logger";
 import {
 	failure,
@@ -17,14 +18,13 @@ import {
 
 export default function AetherChat() {
 	const {
-		geminiApiKey,
-		setGeminiApiKey,
 		chatHistory,
 		addChatMessage,
 		appendChatMessage,
 		clearChatHistory,
 		semanticSearch,
 	} = useAetherStore();
+	const { geminiApiKey, setGeminiApiKey } = useUserConfigStore();
 	const [inputKey, setInputKey] = useState("");
 	const [prompt, setPrompt] = useState("");
 	const [status, setStatus] = useState<RemoteData<void, string>>(notAsked());

--- a/src/pages/NexusAI.tsx
+++ b/src/pages/NexusAI.tsx
@@ -14,6 +14,7 @@ import { useNexusDB } from "../hooks/useNexusDB";
 import { apiBackend } from "../services/aiClient";
 import { useAetherStore } from "../store/aetherStore";
 import { useNexusStore } from "../store/nexusStore";
+import { useUserConfigStore } from "../store/userConfigStore";
 import { truncateContext } from "../utils/aiUtils";
 import {
 	failure,
@@ -31,7 +32,8 @@ interface NexusMessage {
 }
 
 export default function NexusAI() {
-	const { notes, geminiApiKey: apiKey, setGeminiApiKey } = useAetherStore();
+	const { notes } = useAetherStore();
+	const { geminiApiKey: apiKey, setGeminiApiKey } = useUserConfigStore();
 	const { documents } = useNexusStore();
 	const { allDatabases } = useNexusDB();
 

--- a/src/pages/NexusWorkspace.tsx
+++ b/src/pages/NexusWorkspace.tsx
@@ -1,4 +1,4 @@
-import { BlockNoteEditor } from "@blocknote/core";
+import { BlockNoteEditor, type Dictionary } from "@blocknote/core";
 import { lazy, Suspense, useMemo, useState } from "react";
 import { useNexusStore } from "../store/nexusStore";
 import "@blocknote/core/fonts/inter.css";
@@ -34,9 +34,12 @@ export default function NexusWorkspace() {
 		const yDoc = getYDoc(activeDocId);
 
 		return BlockNoteEditor.create({
-			dictionary: esDictionary as any,
+			// #226: cast explícito — esDictionary satisface la forma Dictionary
+			// pero TypeScript no puede inferir el tipo sin el cast.
+			dictionary: esDictionary as unknown as Dictionary,
 			collaboration: {
-				provider: undefined as any, // We are syncing directly to IDB down below through yDoc
+				// provider es opcional en CollaborationOptions; undefined es válido.
+				provider: undefined,
 				fragment: yDoc.getXmlFragment("document-store"),
 				user: {
 					name: "User",
@@ -141,8 +144,9 @@ export default function NexusWorkspace() {
 								</div>
 							}
 						>
+							{/* #226: cast explícito — generics no inferibles en lazy-loaded context */}
 							<BlockNoteView
-								editor={editor as any}
+								editor={editor as unknown as BlockNoteEditor<any, any, any>}
 								theme="dark"
 								className="nexus-editor min-h-[500px]"
 							/>

--- a/src/store/aetherStore.test.ts
+++ b/src/store/aetherStore.test.ts
@@ -22,11 +22,14 @@ vi.mock("../utils/security", () => ({
 }));
 
 import { useAetherStore } from "./aetherStore";
+import { useUserConfigStore } from "./userConfigStore";
 
 function resetStore() {
 	useAetherStore.setState({
 		notes: [],
 		chatHistory: [],
+	});
+	useUserConfigStore.setState({
 		geminiApiKey: "",
 		gmailClientId: "",
 		gmailApiKey: "",
@@ -178,7 +181,7 @@ describe("aetherStore — ingestNote", () => {
 	afterEach(resetStore);
 
 	it("si la nota no existe, retorna sin hacer nada", async () => {
-		useAetherStore.setState({ geminiApiKey: "test-key" });
+		useUserConfigStore.setState({ geminiApiKey: "test-key" });
 		await useAetherStore.getState().ingestNote("note_noexiste" as any);
 		expect(generateEmbedding).not.toHaveBeenCalled();
 	});
@@ -190,7 +193,7 @@ describe("aetherStore — ingestNote", () => {
 	});
 
 	it("si generateEmbedding retorna un vector, actualiza el embedding de la nota", async () => {
-		useAetherStore.setState({ geminiApiKey: "test-key" });
+		useUserConfigStore.setState({ geminiApiKey: "test-key" });
 		const note = useAetherStore.getState().addNote("Test");
 		const vector = [0.1, 0.2, 0.3];
 		vi.mocked(generateEmbedding).mockResolvedValueOnce(vector);
@@ -202,7 +205,7 @@ describe("aetherStore — ingestNote", () => {
 	});
 
 	it("si generateEmbedding retorna null, no actualiza la nota", async () => {
-		useAetherStore.setState({ geminiApiKey: "test-key" });
+		useUserConfigStore.setState({ geminiApiKey: "test-key" });
 		const note = useAetherStore.getState().addNote("Test");
 		vi.mocked(generateEmbedding).mockResolvedValueOnce(null);
 
@@ -227,13 +230,13 @@ describe("aetherStore — semanticSearch", () => {
 	});
 
 	it("si query está vacío, retorna []", async () => {
-		useAetherStore.setState({ geminiApiKey: "test-key" });
+		useUserConfigStore.setState({ geminiApiKey: "test-key" });
 		const result = await useAetherStore.getState().semanticSearch("");
 		expect(result).toEqual([]);
 	});
 
 	it("si generateEmbedding retorna vector, llama findSimilarNotes y retorna el resultado", async () => {
-		useAetherStore.setState({ geminiApiKey: "test-key" });
+		useUserConfigStore.setState({ geminiApiKey: "test-key" });
 		const note = useAetherStore.getState().addNote("Nota");
 		const vector = [0.1, 0.2];
 		vi.mocked(generateEmbedding).mockResolvedValueOnce(vector);
@@ -245,7 +248,7 @@ describe("aetherStore — semanticSearch", () => {
 	});
 
 	it("si generateEmbedding retorna null, retorna []", async () => {
-		useAetherStore.setState({ geminiApiKey: "test-key" });
+		useUserConfigStore.setState({ geminiApiKey: "test-key" });
 		vi.mocked(generateEmbedding).mockResolvedValueOnce(null);
 
 		const result = await useAetherStore.getState().semanticSearch("query");

--- a/src/store/aetherStore.ts
+++ b/src/store/aetherStore.ts
@@ -1,5 +1,5 @@
-// TODO AR-03 (#195): aetherStore tiene 3 responsabilidades (notas, embeddings,
-// config global). Separar en noteStore + embeddingStore + userConfigStore — ver #195.
+// AR-03 (#234): API keys extraídas a userConfigStore. aetherStore conserva
+// notas + embeddings. La separación de embeddingStore queda pendiente (gradual).
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 import { create } from "zustand";
@@ -9,6 +9,7 @@ import { findSimilarNotes, generateEmbedding } from "../utils/embeddings";
 import { idbStorage } from "../utils/idbStorage";
 import { logger } from "../utils/logger";
 import type { AetherNoteId, ChatMessageId } from "../utils/schemas";
+import { useUserConfigStore } from "./userConfigStore";
 
 export type { AetherNoteId, ChatMessageId };
 
@@ -41,9 +42,6 @@ export interface ChatMessage {
 
 interface AetherState {
 	notes: AetherNote[];
-	geminiApiKey: string;
-	gmailClientId: string;
-	gmailApiKey: string;
 	chatHistory: ChatMessage[];
 }
 
@@ -54,9 +52,6 @@ interface AetherActions {
 	getNote: (id: AetherNoteId) => AetherNote | undefined;
 	getGraphData: () => GraphData;
 	findBacklinks: (nodeId: AetherNoteId) => AetherNote[];
-	setGeminiApiKey: (key: string) => void;
-	setGmailClientId: (id: string) => void;
-	setGmailApiKey: (key: string) => void;
 	ingestNote: (id: AetherNoteId) => Promise<void>;
 	semanticSearch: (query: string, limit?: number) => Promise<AetherNote[]>;
 	addChatMessage: (
@@ -96,9 +91,6 @@ export const useAetherStore = create<AetherState & AetherActions>()(
 
 			return {
 				notes: defaultNotes,
-				geminiApiKey: "",
-				gmailClientId: "",
-				gmailApiKey: "",
 				chatHistory: [],
 
 				addNote: (title = "Nueva Nota") => {
@@ -169,27 +161,9 @@ export const useAetherStore = create<AetherState & AetherActions>()(
 					});
 				},
 
-				setGeminiApiKey: (key) => {
-					set((state) => {
-						state.geminiApiKey = key;
-					});
-					window.cortexAPI?.config.set("gemini_api_key", key);
-				},
-				setGmailClientId: (id) => {
-					set((state) => {
-						state.gmailClientId = id;
-					});
-					window.cortexAPI?.config.set("gmail_client_id", id);
-				},
-				setGmailApiKey: (key) => {
-					set((state) => {
-						state.gmailApiKey = key;
-					});
-					window.cortexAPI?.config.set("gmail_api_key", key);
-				},
-
 				ingestNote: async (id) => {
-					const { notes, geminiApiKey } = get();
+					const { notes } = get();
+					const { geminiApiKey } = useUserConfigStore.getState();
 					const note = notes.find((n) => n.id === id);
 					if (!note || !geminiApiKey) return;
 
@@ -208,7 +182,8 @@ export const useAetherStore = create<AetherState & AetherActions>()(
 				},
 
 				semanticSearch: async (query, limit = 3) => {
-					const { notes, geminiApiKey } = get();
+					const { notes } = get();
+					const { geminiApiKey } = useUserConfigStore.getState();
 					if (!geminiApiKey || !query) return [];
 
 					const queryVector = await generateEmbedding(geminiApiKey, query);
@@ -292,7 +267,7 @@ export const useAetherStore = create<AetherState & AetherActions>()(
 					api.config.get("gmail_client_id"),
 					api.config.get("gmail_api_key"),
 				]);
-				useAetherStore.setState({
+				useUserConfigStore.setState({
 					geminiApiKey: geminiKey ?? "",
 					gmailClientId: gmailId ?? "",
 					gmailApiKey: gmailKey ?? "",

--- a/src/store/nexusStore.test.ts
+++ b/src/store/nexusStore.test.ts
@@ -88,10 +88,12 @@ describe("nexusStore — mutaciones de documentos", () => {
 
 	it("persiste documentos en localStorage tras addDocument", () => {
 		useNexusStore.getState().addDocument("Persistido");
-		const raw = localStorage.getItem("lti_nexus_docs");
+		// AR-06 (#235): clave migrada de "lti_nexus_docs" (array crudo) a
+		// "lti_nexus_state" (formato zustand persist: { state, version })
+		const raw = localStorage.getItem("lti_nexus_state");
 		expect(raw).not.toBeNull();
 		const parsed = JSON.parse(raw!);
-		expect(parsed[0].title).toBe("Persistido");
+		expect(parsed.state.documents[0].title).toBe("Persistido");
 	});
 });
 

--- a/src/store/nexusStore.ts
+++ b/src/store/nexusStore.ts
@@ -1,12 +1,12 @@
-// TODO AR-06 (#207): nexusStore usa localStorage manual mientras aetherStore usa
-// Zustand persist middleware. Migrar a persist para consistencia — ver issue #207.
+// AR-06 (#235): migrado de localStorage manual a Zustand persist middleware
+// para consistencia con aetherStore y observerStore.
 import { enableMapSet } from "immer";
 import { v4 as uuidv4 } from "uuid";
 import { IndexeddbPersistence } from "y-indexeddb";
 import * as Y from "yjs";
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
-import { safeParseJSON } from "../utils/safeStorage";
 import type { NexusDocumentId } from "../utils/schemas";
 
 export type { NexusDocumentId };
@@ -39,18 +39,9 @@ interface NexusActions {
 }
 
 export const useNexusStore = create<NexusState & NexusActions>()(
-	immer((set, get) => {
-		const initialDocuments = safeParseJSON<NexusDocument[]>(
-			"lti_nexus_docs",
-			[],
-		);
-
-		const syncDocuments = (docs: NexusDocument[]) => {
-			localStorage.setItem("lti_nexus_docs", JSON.stringify(docs));
-		};
-
-		return {
-			documents: initialDocuments,
+	persist(
+		immer((set, get) => ({
+			documents: [],
 			yDocs: {},
 			yDocsCreating: new Set(),
 
@@ -64,7 +55,6 @@ export const useNexusStore = create<NexusState & NexusActions>()(
 				};
 				set((state) => {
 					state.documents.unshift(newDoc);
-					syncDocuments(state.documents);
 				});
 				return newDoc;
 			},
@@ -75,7 +65,6 @@ export const useNexusStore = create<NexusState & NexusActions>()(
 					if (doc) {
 						Object.assign(doc, updates);
 						doc.updatedAt = Date.now();
-						syncDocuments(state.documents);
 					}
 				});
 			},
@@ -88,8 +77,6 @@ export const useNexusStore = create<NexusState & NexusActions>()(
 
 				set((state) => {
 					state.documents = state.documents.filter((doc) => doc.id !== id);
-					syncDocuments(state.documents);
-
 					delete state.yDocs[id];
 				});
 			},
@@ -123,6 +110,29 @@ export const useNexusStore = create<NexusState & NexusActions>()(
 
 				return ydoc;
 			},
-		};
-	}),
+		})),
+		{
+			name: "lti_nexus_state", // nueva clave — evita conflicto de formato con la legacy
+			storage: createJSONStorage(() => localStorage),
+			// Solo persiste los metadatos del documento; yDocs/yDocsCreating son runtime.
+			partialize: (state) => ({ documents: state.documents }),
+			onRehydrateStorage: () => (state) => {
+				if (!state || state.documents.length > 0) return;
+				// Migración one-shot: si no hay documentos y existe la clave legacy,
+				// importar los datos del formato anterior (array JSON crudo).
+				try {
+					const legacy = localStorage.getItem("lti_nexus_docs");
+					if (legacy) {
+						const docs = JSON.parse(legacy) as NexusDocument[];
+						if (Array.isArray(docs) && docs.length > 0) {
+							state.documents = docs;
+							localStorage.removeItem("lti_nexus_docs");
+						}
+					}
+				} catch {
+					// ignorar: si la migración falla el usuario empieza con lista vacía
+				}
+			},
+		},
+	),
 );

--- a/src/store/userConfigStore.ts
+++ b/src/store/userConfigStore.ts
@@ -1,0 +1,53 @@
+/**
+ * Store de configuración del usuario (API keys de servicios externos).
+ *
+ * AR-03 (#234): extraído de aetherStore para eliminar la responsabilidad
+ * mixta de notas + embeddings + configuración global.
+ *
+ * Las API keys NO se persisten en localStorage/IDB — se almacenan en el
+ * OS Keychain vía cortexAPI (#109). Este store es el punto de acceso
+ * reactivo a esos valores en el renderer.
+ */
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+
+interface UserConfigState {
+	geminiApiKey: string;
+	gmailClientId: string;
+	gmailApiKey: string;
+}
+
+interface UserConfigActions {
+	setGeminiApiKey: (key: string) => void;
+	setGmailClientId: (id: string) => void;
+	setGmailApiKey: (key: string) => void;
+}
+
+export const useUserConfigStore = create<UserConfigState & UserConfigActions>()(
+	immer((set) => ({
+		geminiApiKey: "",
+		gmailClientId: "",
+		gmailApiKey: "",
+
+		setGeminiApiKey: (key) => {
+			set((state) => {
+				state.geminiApiKey = key;
+			});
+			window.cortexAPI?.config.set("gemini_api_key", key);
+		},
+
+		setGmailClientId: (id) => {
+			set((state) => {
+				state.gmailClientId = id;
+			});
+			window.cortexAPI?.config.set("gmail_client_id", id);
+		},
+
+		setGmailApiKey: (key) => {
+			set((state) => {
+				state.gmailApiKey = key;
+			});
+			window.cortexAPI?.config.set("gmail_api_key", key);
+		},
+	})),
+);


### PR DESCRIPTION
## Issues cerrados
Closes #226, #227, #234, #235, #239

## Resumen

- **#234 — AR-03**: Extrae API keys a `userConfigStore` (nuevo store dedicado). `aetherStore` conserva solo notas + embeddings. Actualiza `AetherChat`, `NexusAI`, `useCloudSync` y `GmailWidget` para consumir el nuevo store. `onRehydrateStorage` en `aetherStore` llama a `useUserConfigStore.setState`.
- **#235 — AR-06**: Migra `nexusStore` de localStorage manual (`lti_nexus_docs`) a Zustand `persist` middleware (clave `lti_nexus_state`). `onRehydrateStorage` importa docs legacy y limpia la clave antigua.
- **#227**: Descompone `GmailWidget` (~110 LOC) en tres subcomponentes: `GmailMinimized`, `GmailSettingsPanel` y `GmailInbox`, reduciendo responsabilidades y mejorando testabilidad.
- **#226**: Corrige tipos BlockNote en `NexusWorkspace` (`Dictionary`, `CollaborationOptions`, `BlockNoteEditor<any,any,any>`), eliminando casts `as any` directos.
- **#239 — SC-07**: Documenta en `electron/main.ts` por qué `unsafe-inline` es necesario en la CSP de Electron (Vite + file://) y lista las mitigaciones compensatorias.

## Test plan
- [ ] `npx vitest run` → 767/768 passed (1 skipped), 0 failed
- [ ] `npx tsc -b --noEmit` → sin errores
- [ ] `npx biome check` → sin errores
- [ ] CI verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)