### PR TITLE
fix(build): aumentar chunkSizeWarningLimit a 2000 en vite.config (#298)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
 		port: 5173,
 	},
 	build: {
+		chunkSizeWarningLimit: 2000,
 		cssMinify: true,
 		rollupOptions: {
 			output: {


### PR DESCRIPTION
## Qué se cambió

Agrega `chunkSizeWarningLimit: 2000` en la sección `build` de `vite.config.ts`.

- Los chunks `vendor-ui` (~1.8MB) y `vendor-blocknote` (~1.5MB) superan el límite default de 500KB de Vite, generando warnings en cada build.
- Lazy loading no aplica en esta app Electron (todos los módulos son necesarios al inicio).
- El valor 2000KB cubre los chunks actuales y tiene margen para crecimiento moderado.
- Typecheck (`tsc -b --noEmit`) pasa sin errores.

## Issues que cierra

Closes #298

## Milestone

v3.11.0