### PR TITLE
fix(v3.14.0-p1): security hardening & TypeScript strictness

### DIFF
--- a/electron/handlers/configHandlers.ts
+++ b/electron/handlers/configHandlers.ts
@@ -32,6 +32,8 @@ export const ALLOWED_CONFIG_KEYS = new Set([
 	"gmail_api_key",
 	"cortex_update_channel",
 	"llm_api_key",
+	"google_ai_api_key", // SC-03 (#309): clave usada en migración desde VITE_GOOGLE_AI_API_KEY
+	"firebase_api_key", // SC-03 (#309): clave usada en migración desde VITE_FIREBASE_API_KEY
 ]);
 
 export interface ConfigHandlers {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -161,12 +161,24 @@ function initRuVector(): void {
 	});
 	const ruVector = makeRuVectorHandlers(adapter);
 
-	ipcMain.handle("cortex:index", (_event, docPath: string) => {
+	ipcMain.handle("cortex:index", (_event, docPath: unknown) => {
 		rateLimiters.cortexIndex();
+		// SC-04 (#310): validar tipo en boundary IPC antes de delegar al handler
+		if (typeof docPath !== "string" || docPath.length === 0) {
+			throw new Error(
+				`cortex:index — docPath debe ser un string no vacío, recibido: ${JSON.stringify(docPath)}`,
+			);
+		}
 		return ruVector.cortexIndex(docPath);
 	});
-	ipcMain.handle("cortex:query", (_event, text: string, topK?: unknown) => {
+	ipcMain.handle("cortex:query", (_event, text: unknown, topK?: unknown) => {
 		rateLimiters.cortexQuery();
+		// SC-04 (#310): validar text en boundary IPC
+		if (typeof text !== "string" || text.length === 0) {
+			throw new Error(
+				`cortex:query — text debe ser un string no vacío, recibido: ${JSON.stringify(text)}`,
+			);
+		}
 		// SC-01 (#278): validar topK en la boundary IPC antes de delegar al handler
 		if (
 			topK !== undefined &&
@@ -202,16 +214,39 @@ function initDocling(): void {
 	});
 	const docling = makeDoclingHandlers(adapter);
 
-	ipcMain.handle("cortex:process-document", (_event, docPath: string) => {
+	ipcMain.handle("cortex:process-document", (_event, docPath: unknown) => {
 		rateLimiters.cortexProcessDocument();
+		// SC-04 (#310): validar tipo en boundary IPC antes de delegar al handler
+		if (typeof docPath !== "string" || docPath.length === 0) {
+			throw new Error(
+				`cortex:process-document — docPath debe ser un string no vacío, recibido: ${JSON.stringify(docPath)}`,
+			);
+		}
 		return docling.processDocument(docPath);
 	});
-	ipcMain.handle("cortex:ocr", (_event, imagePath: string) => {
+	ipcMain.handle("cortex:ocr", (_event, imagePath: unknown) => {
 		rateLimiters.cortexOcr();
+		// SC-04 (#310): validar tipo en boundary IPC antes de delegar al handler
+		if (typeof imagePath !== "string" || imagePath.length === 0) {
+			throw new Error(
+				`cortex:ocr — imagePath debe ser un string no vacío, recibido: ${JSON.stringify(imagePath)}`,
+			);
+		}
 		return docling.ocr(imagePath);
 	});
 
 	logger.info("Docling", "handlers registrados");
+}
+
+// ── Helpers de CSP ────────────────────────────────────────────────────────────
+// SC-01 (#308): construir origins de Firebase Realtime Database sin wildcard.
+// VITE_FIREBASE_PROJECT_ID está disponible en dev (via vite-plugin-electron).
+// En producción sin la variable, se omiten los origins de firebaseio.com ya que
+// sin project ID configurado Firebase RTDB no se usa.
+function buildFirebaseRTDBOrigins(): string {
+	const projectId = process.env.VITE_FIREBASE_PROJECT_ID;
+	if (!projectId) return "";
+	return `https://${projectId}.firebaseio.com wss://${projectId}.firebaseio.com`;
 }
 
 // ── CSP via main process — Issue #175 ─────────────────────────────────────────
@@ -238,6 +273,19 @@ function initDocling(): void {
 // La combinación de sandbox + contextIsolation elimina el vector de escalada
 // de privilegios incluso si un atacante logra ejecutar JS en el renderer.
 function setupCSP(): void {
+	// SC-01 (#308): resolver origins de Firebase RTDB sin wildcard en tiempo de arranque
+	const firebaseRTDBOrigins = buildFirebaseRTDBOrigins();
+	const connectSrc = [
+		"'self'",
+		"https://generativelanguage.googleapis.com",
+		"https://identitytoolkit.googleapis.com",
+		"https://firestore.googleapis.com",
+		"https://securetoken.googleapis.com",
+		// SC-09 (#210) + SC-01 (#308): subdominio específico cuando el project ID está disponible;
+		// omitido si Firebase RTDB no está configurado (firebaseRTDBOrigins === "")
+		...(firebaseRTDBOrigins ? [firebaseRTDBOrigins] : []),
+	].join(" ");
+
 	session.defaultSession.webRequest.onHeadersReceived(
 		{ urls: ["<all_urls>"] },
 		(details, callback) => {
@@ -251,8 +299,7 @@ function setupCSP(): void {
 							"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
 							"font-src 'self' data: https://fonts.gstatic.com",
 							"img-src 'self' data: https:",
-							// SC-09 (#210): allowlist explícita — sin wildcards de subdominio
-							"connect-src 'self' https://generativelanguage.googleapis.com https://identitytoolkit.googleapis.com https://firestore.googleapis.com https://securetoken.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com",
+							`connect-src ${connectSrc}`,
 							"object-src 'none'",
 							"frame-src 'none'",
 						].join("; "),

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from "electron";
+import type { CortexChunk } from "./types.d.ts";
 
 /**
  * API expuesta al Renderer Process vía contextBridge.
@@ -21,8 +22,8 @@ contextBridge.exposeInMainWorld("cortexAPI", {
 	cortex: {
 		index: (docPath: string): Promise<{ chunks: number }> =>
 			ipcRenderer.invoke("cortex:index", docPath),
-		query: (text: string, topK?: number): Promise<unknown[]> =>
-			ipcRenderer.invoke("cortex:query", text, topK),
+		query: (text: string, topK?: number): Promise<CortexChunk[]> =>
+			ipcRenderer.invoke("cortex:query", text, topK) as Promise<CortexChunk[]>,
 		processDocument: (
 			docPath: string,
 		): Promise<{ chunks: number; text: string }> =>

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -129,14 +129,15 @@ const PLATFORM_MAP = {
 };
 
 // SHA-256 de cada binario — se actualiza con cada release de RuVector.
-// "0000..." es un placeholder hasta que exista el primer release real.
+// SC-02 (#312): usar "0000..." como placeholder explícito hasta el primer release real.
+// Al publicar un release, calcular con: sha256sum ruvector-{platform}
+// y reemplazar el valor correspondiente.
+const SHA256_PLACEHOLDER =
+	"0000000000000000000000000000000000000000000000000000000000000000";
 const SHA256 = {
-	"linux-x64":
-		"0000000000000000000000000000000000000000000000000000000000000000",
-	"darwin-x64":
-		"0000000000000000000000000000000000000000000000000000000000000000",
-	"win32-x64":
-		"0000000000000000000000000000000000000000000000000000000000000000",
+	"linux-x64": SHA256_PLACEHOLDER,
+	"darwin-x64": SHA256_PLACEHOLDER,
+	"win32-x64": SHA256_PLACEHOLDER,
 };
 
 async function installRuVector() {
@@ -184,10 +185,18 @@ async function installRuVector() {
 		const buffer = await res.arrayBuffer();
 		const bytes = new Uint8Array(buffer);
 
-		// Verificar checksum SHA-256
+		// Verificar checksum SHA-256 — SC-02 (#312)
 		const hash = createHash("sha256").update(bytes).digest("hex");
 		const expected = SHA256[platform];
-		if (hash !== expected) {
+		if (expected === SHA256_PLACEHOLDER) {
+			// Hash pendiente de release real — verificación omitida intencionalmente.
+			// Actualizar SHA256[platform] en este archivo al publicar el release de RuVector.
+			note(
+				pc.yellow(
+					`[setup] SHA-256 de RuVector no configurado — verificación de integridad omitida.\nActualizar SHA256["${platform}"] en scripts/setup.mjs al publicar el release.`,
+				),
+			);
+		} else if (hash !== expected) {
 			throw new Error(
 				`Checksum inválido: esperado ${expected}, obtenido ${hash}`,
 			);

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -13,6 +13,8 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true,
+		"noUncheckedIndexedAccess": true,
+		"exactOptionalPropertyTypes": true,
 		"types": ["node"]
 	},
 	"include": ["electron"],


### PR DESCRIPTION
## Resumen

Fixes de seguridad y rigor de tipos encontrados en auditoría post-deprecación v3.13.0.

### SC-01 (#308) — CSP sin wildcard de subdominio Firebase
- `electron/main.ts`: nueva función `buildFirebaseRTDBOrigins()` que usa `VITE_FIREBASE_PROJECT_ID` para construir `PROJECT_ID.firebaseio.com` en lugar de `*.firebaseio.com`. Si el project ID no está disponible, los origins de Firebase RTDB se omiten del CSP.

### SC-02 (#312) — SHA-256 placeholder explícito en setup.mjs
- Extrae `SHA256_PLACEHOLDER` como constante. Cuando el hash esperado es el placeholder, la verificación se omite con un aviso claro. Cuando se publique el release real de RuVector, la verificación es automáticamente estricta.

### SC-03 (#309) — firebase_api_key y google_ai_api_key en ALLOWED_CONFIG_KEYS
- `configHandlers.ts`: agrega las dos claves que la migración desde `.env` intenta persistir pero que eran rechazadas silenciosamente por el handler.

### SC-04 (#310) — Validación de tipo en boundary IPC
- `electron/main.ts`: guards `typeof param !== 'string' || param.length === 0` para `docPath` en `cortex:index` y `cortex:process-document`, `imagePath` en `cortex:ocr`, y `text` en `cortex:query`. Consistente con la validación de `topK` ya existente.

### DX-01 (#315) — tsconfig.electron.json strictness
- Agrega `noUncheckedIndexedAccess: true` y `exactOptionalPropertyTypes: true`. Sin errores de compilación en electron/ tras el cambio.

### DX-02 (#313) — preload.ts tipo correcto para cortex.query
- Cambia `Promise<unknown[]>` a `Promise<CortexChunk[]>` (con cast explícito). Importa `CortexChunk` desde `./types.d.ts`.

## Test plan
- [x] 731/731 tests pasando localmente
- [x] `tsc --project tsconfig.electron.json --noEmit` sin errores
- [x] `biome check` sin errores de formato