### PR TITLE
fix(v3.14.0-p3): quality polish & DX improvements

### DIFF
--- a/electron/subprocess/CircuitBreaker.ts
+++ b/electron/subprocess/CircuitBreaker.ts
@@ -15,7 +15,7 @@
  *               Si falla       → OPEN de nuevo (con timer reiniciado).
  *
  * Uso:
- *   const cb = new CircuitBreaker({ name: "whisper", failureThreshold: 3 });
+ *   const cb = new CircuitBreaker({ name: "docling", failureThreshold: 3 });
  *   const result = await cb.call(() => adapter.request(...));
  */
 

--- a/electron/subprocess/SubprocessAdapter.test.ts
+++ b/electron/subprocess/SubprocessAdapter.test.ts
@@ -73,42 +73,4 @@ describe("SubprocessAdapter — Docling (OCR)", () => {
 	});
 });
 
-describe("SubprocessAdapter — Whisper (transcripción)", () => {
-	let transport: ReturnType<typeof makeMockTransport>;
-	let adapter: SubprocessAdapter;
-
-	beforeEach(() => {
-		transport = makeMockTransport();
-		adapter = new SubprocessAdapter({
-			name: "whisper",
-			transport: transport as never,
-		});
-	});
-
-	it("should_send_transcribe_request_and_return_text", async () => {
-		transport.send.mockResolvedValueOnce({
-			id: "req-4",
-			status: "ok",
-			data: { text: "El teorema de Bayes establece..." },
-		});
-
-		const result = await adapter.request({
-			id: "req-4",
-			action: "transcribe",
-			payload: { path: "/tmp/audio.wav" },
-		});
-		expect(result.status).toBe("ok");
-		expect((result.data as Record<string, unknown>).text).toContain("Bayes");
-	});
-
-	it("should_include_subprocess_name_in_timeout_error", async () => {
-		transport.send.mockImplementationOnce(() => new Promise(() => {}));
-
-		await expect(
-			adapter.request(
-				{ id: "req-5", action: "transcribe", payload: {} },
-				{ timeoutMs: 50 },
-			),
-		).rejects.toThrow("whisper");
-	});
-});
+// QP-03 (#322): bloque Whisper eliminado — Whisper deprecado en v3.13.0 (ADR-009)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"lint": "biome check .",
 		"lint:fix": "biome check --write .",
 		"type-check": "tsc -b --noEmit",
+		"type-check:electron": "tsc --project tsconfig.electron.json --noEmit",
 		"format": "biome format --write .",
 		"test": "vitest run",
 		"test:watch": "vitest",

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -219,7 +219,7 @@ async function installRuVector() {
 	}
 }
 
-// --- Python (Docling + Whisper) ---
+// --- Python (Docling) ---
 
 const VENV_DIR = join(homedir(), ".carrera-lti", "venv");
 const VENV_PYTHON = join(
@@ -473,7 +473,7 @@ Redirect URI: ${pc.cyan("http://localhost:5173/")} (¡No olvides la barra final!
 	// 6. RuVector
 	await installRuVector();
 
-	// 7. Python (Docling + Whisper)
+	// 7. Python (Docling)
 	await installPythonDeps();
 
 	outro(pc.green("Tu sistema está listo para operar en Estado de Flow."));

--- a/src/components/dashboard/GmailWidget.test.tsx
+++ b/src/components/dashboard/GmailWidget.test.tsx
@@ -47,7 +47,7 @@ function setupStore({
 		gmailApiKey,
 		setGmailClientId: vi.fn(),
 		setGmailApiKey: vi.fn(),
-	} as any);
+	} as ReturnType<typeof useUserConfigStore>);
 }
 
 beforeEach(() => {
@@ -80,7 +80,7 @@ describe("GmailWidget — estado minimizado", () => {
 	it("renderiza estado minimizado cuando isMinimized es true (estado inicial)", async () => {
 		setupStore({ gmailClientId: "client-id", gmailApiKey: "api-key" });
 		vi.mocked(gmailService.isAuthenticated).mockReturnValue(false);
-		vi.mocked(gmailService.initialize).mockResolvedValue(undefined as any);
+		vi.mocked(gmailService.initialize).mockResolvedValue(undefined);
 
 		await act(async () => {
 			render(<GmailWidget />);
@@ -98,7 +98,7 @@ describe("GmailWidget — estado de loading", () => {
 
 		// initialize resuelve y isAuthenticated true → llama fetchEmails que tarda
 		vi.mocked(gmailService.isAuthenticated).mockReturnValue(true);
-		vi.mocked(gmailService.initialize).mockResolvedValue(undefined as any);
+		vi.mocked(gmailService.initialize).mockResolvedValue(undefined);
 		vi.mocked(gmailService.fetchUnreadMessages).mockImplementation(
 			() => new Promise(() => {}), // Never resolves — simula loading
 		);
@@ -118,7 +118,7 @@ describe("GmailWidget — estado de error", () => {
 		setupStore({ gmailClientId: "client-id", gmailApiKey: "api-key" });
 
 		vi.mocked(gmailService.isAuthenticated).mockReturnValue(true);
-		vi.mocked(gmailService.initialize).mockResolvedValue(undefined as any);
+		vi.mocked(gmailService.initialize).mockResolvedValue(undefined);
 		vi.mocked(gmailService.fetchUnreadMessages).mockRejectedValue(
 			new Error("Network error"),
 		);

--- a/src/cortex/ui/CortexActivityIndicator.tsx
+++ b/src/cortex/ui/CortexActivityIndicator.tsx
@@ -1,19 +1,5 @@
-import { type CortexActivity, useCortexStore } from "./cortexStore";
-
-function activityLabel(activity: CortexActivity): string {
-	switch (activity.type) {
-		case "idle":
-			return "Inactivo";
-		case "indexing":
-			return `Indexando: ${activity.docTitle}`;
-		case "querying":
-			return `Consultando: ${activity.query}`;
-		case "query_error":
-			return `Error: ${activity.error}`;
-		case "ocr":
-			return `OCR: ${activity.filename}`;
-	}
-}
+import { useCortexStore } from "./cortexStore";
+import { activityLabel } from "./activityLabel";
 
 /**
  * Indicador compacto del estado actual de Cortex.

--- a/src/cortex/ui/CortexActivityIndicator.tsx
+++ b/src/cortex/ui/CortexActivityIndicator.tsx
@@ -1,5 +1,5 @@
-import { useCortexStore } from "./cortexStore";
 import { activityLabel } from "./activityLabel";
+import { useCortexStore } from "./cortexStore";
 
 /**
  * Indicador compacto del estado actual de Cortex.

--- a/src/cortex/ui/CortexTab.tsx
+++ b/src/cortex/ui/CortexTab.tsx
@@ -1,5 +1,5 @@
-import { useCortexStore } from "./cortexStore";
 import { activityLabel } from "./activityLabel";
+import { useCortexStore } from "./cortexStore";
 
 function formatTs(ts: number | null): string {
 	if (ts === null) return "Nunca";

--- a/src/cortex/ui/CortexTab.tsx
+++ b/src/cortex/ui/CortexTab.tsx
@@ -1,19 +1,5 @@
-import { type CortexActivity, useCortexStore } from "./cortexStore";
-
-function activityLabel(activity: CortexActivity): string {
-	switch (activity.type) {
-		case "idle":
-			return "Inactivo";
-		case "indexing":
-			return `Indexando: ${activity.docTitle}`;
-		case "querying":
-			return `Consultando: ${activity.query}`;
-		case "query_error":
-			return `Error: ${activity.error}`;
-		case "ocr":
-			return `OCR: ${activity.filename}`;
-	}
-}
+import { useCortexStore } from "./cortexStore";
+import { activityLabel } from "./activityLabel";
 
 function formatTs(ts: number | null): string {
 	if (ts === null) return "Nunca";

--- a/src/cortex/ui/activityLabel.ts
+++ b/src/cortex/ui/activityLabel.ts
@@ -1,0 +1,28 @@
+import type { CortexActivity } from "./cortexStore";
+
+/**
+ * Devuelve la etiqueta de texto para el estado de actividad de Cortex.
+ *
+ * QP-01 (#317): rama `default` con never-check para detectar en compilación
+ * si se añade un nuevo tipo al union sin actualizar este switch.
+ *
+ * QP-02 (#323): extraída de CortexActivityIndicator y CortexTab para evitar duplicación.
+ */
+export function activityLabel(activity: CortexActivity): string {
+	switch (activity.type) {
+		case "idle":
+			return "Inactivo";
+		case "indexing":
+			return `Indexando: ${activity.docTitle}`;
+		case "querying":
+			return `Consultando: ${activity.query}`;
+		case "query_error":
+			return `Error: ${activity.error}`;
+		case "ocr":
+			return `OCR: ${activity.filename}`;
+		default: {
+			const _exhaustive: never = activity;
+			return `Desconocido: ${(_exhaustive as CortexActivity).type}`;
+		}
+	}
+}

--- a/src/cortex/ui/cortexStore.ts
+++ b/src/cortex/ui/cortexStore.ts
@@ -28,6 +28,8 @@ export interface CortexState {
 
 interface CortexActions {
 	setActivity: (activity: CortexActivity) => void;
+	/** AR-03 (#327): muta solo activity.progress sin re-setear docTitle. No-op si activity.type !== "indexing". */
+	setIndexingProgress: (progress: number) => void;
 	setIndexedDocCount: (count: number) => void;
 	setLastIndexedAt: (ts: number) => void;
 	setQueryResults: (results: CortexChunk[]) => void;
@@ -48,6 +50,13 @@ export const useCortexStore = create<CortexState & CortexActions>()(
 		setActivity: (activity) =>
 			set((s) => {
 				s.activity = activity;
+			}),
+
+		setIndexingProgress: (progress) =>
+			set((s) => {
+				if (s.activity.type === "indexing") {
+					s.activity.progress = progress;
+				}
 			}),
 
 		setIndexedDocCount: (count) =>

--- a/src/pages/Examenes.test.tsx
+++ b/src/pages/Examenes.test.tsx
@@ -34,7 +34,7 @@ function setupHooks() {
 	vi.mocked(useAcademicCalendar).mockReturnValue({
 		academicDates: mockAcademicDates,
 		updateAcademicDates: vi.fn(),
-	} as any);
+	} as ReturnType<typeof useAcademicCalendar>);
 
 	vi.mocked(useSubjectData).mockReturnValue({
 		allSubjects: mockSubjects,
@@ -47,7 +47,7 @@ function setupHooks() {
 		getApprovedCount: vi.fn(),
 		getApprovedCredits: vi.fn(),
 		getAverage: vi.fn(),
-	} as any);
+	} as unknown as ReturnType<typeof useSubjectData>);
 }
 
 describe("Examenes", () => {

--- a/src/pages/Horarios.test.tsx
+++ b/src/pages/Horarios.test.tsx
@@ -93,7 +93,7 @@ describe("Horarios — subjectStatusById Map", () => {
 			getApprovedCount: vi.fn(),
 			getApprovedCredits: vi.fn(),
 			getAverage: vi.fn(),
-		} as any);
+		} as ReturnType<typeof useSubjectData>);
 
 		render(<Horarios schedule={[]} onUpdateSchedule={vi.fn()} />);
 		// Si el componente renderizó sin errores, el Map se construyó correctamente
@@ -119,7 +119,7 @@ describe("Horarios — items filter", () => {
 			getApprovedCount: vi.fn(),
 			getApprovedCredits: vi.fn(),
 			getAverage: vi.fn(),
-		} as any);
+		} as ReturnType<typeof useSubjectData>);
 
 		const schedule: ScheduleItem[] = [
 			{ id: "item-1", subjectId: "s1", day: 1 },
@@ -145,7 +145,7 @@ describe("Horarios — items filter", () => {
 			getApprovedCount: vi.fn(),
 			getApprovedCredits: vi.fn(),
 			getAverage: vi.fn(),
-		} as any);
+		} as ReturnType<typeof useSubjectData>);
 
 		expect(() =>
 			render(<Horarios schedule={[]} onUpdateSchedule={vi.fn()} />),
@@ -167,7 +167,7 @@ describe("Horarios — items con status no-en_curso no aparecen", () => {
 			getApprovedCount: vi.fn(),
 			getApprovedCredits: vi.fn(),
 			getAverage: vi.fn(),
-		} as any);
+		} as ReturnType<typeof useSubjectData>);
 
 		const schedule: ScheduleItem[] = [
 			{ id: "item-2", subjectId: "s2", day: 3 },
@@ -194,7 +194,7 @@ describe("Horarios — items con status no-en_curso no aparecen", () => {
 			getApprovedCount: vi.fn(),
 			getApprovedCredits: vi.fn(),
 			getAverage: vi.fn(),
-		} as any);
+		} as ReturnType<typeof useSubjectData>);
 
 		const schedule: ScheduleItem[] = [
 			{ id: "item-1", subjectId: "s1", day: 1 },

--- a/src/pages/MallaCurricular.test.tsx
+++ b/src/pages/MallaCurricular.test.tsx
@@ -36,7 +36,7 @@ describe("MallaCurricular — currentSemester", () => {
 			getApprovedCount: vi.fn(),
 			getApprovedCredits: vi.fn(),
 			getAverage: vi.fn(),
-		} as any);
+		} as ReturnType<typeof useSubjectData>);
 
 		render(<MallaCurricular />);
 		// El semestre 1 debe aparecer resaltado (no es posible verificar CSS pero sí que la
@@ -58,7 +58,7 @@ describe("MallaCurricular — currentSemester", () => {
 			getApprovedCount: vi.fn(),
 			getApprovedCredits: vi.fn(),
 			getAverage: vi.fn(),
-		} as any);
+		} as ReturnType<typeof useSubjectData>);
 
 		render(<MallaCurricular />);
 		// El semestre 3 debe estar presente y ser el mínimo
@@ -80,7 +80,7 @@ describe("MallaCurricular — cálculo de créditos", () => {
 			getApprovedCount: vi.fn(),
 			getApprovedCredits: vi.fn(),
 			getAverage: vi.fn(),
-		} as any);
+		} as ReturnType<typeof useSubjectData>);
 
 		render(<MallaCurricular />);
 		// creditsDone se muestra en la card "Obtenidos"
@@ -100,7 +100,7 @@ describe("MallaCurricular — cálculo de créditos", () => {
 			getApprovedCount: vi.fn(),
 			getApprovedCredits: vi.fn(),
 			getAverage: vi.fn(),
-		} as any);
+		} as ReturnType<typeof useSubjectData>);
 
 		render(<MallaCurricular />);
 		// creditsActive aparece en la card "En Curso"
@@ -125,7 +125,7 @@ describe("MallaCurricular — cálculo de créditos", () => {
 			getApprovedCount: vi.fn(),
 			getApprovedCredits: vi.fn(),
 			getAverage: vi.fn(),
-		} as any);
+		} as ReturnType<typeof useSubjectData>);
 
 		render(<MallaCurricular />);
 		expect(screen.getByText(String(totalPending))).toBeInTheDocument();
@@ -151,7 +151,7 @@ describe("MallaCurricular — tcDone", () => {
 			getApprovedCount: vi.fn(),
 			getApprovedCredits: vi.fn(),
 			getAverage: vi.fn(),
-		} as any);
+		} as ReturnType<typeof useSubjectData>);
 
 		render(<MallaCurricular />);
 		// tcDone debe ser solo los créditos de subjectSem1 (sem 5 no cuenta)
@@ -188,7 +188,7 @@ describe("MallaCurricular — pct", () => {
 			getApprovedCount: vi.fn(),
 			getApprovedCredits: vi.fn(),
 			getAverage: vi.fn(),
-		} as any);
+		} as ReturnType<typeof useSubjectData>);
 
 		render(<MallaCurricular />);
 		expect(screen.getByText(`${expectedPct}%`)).toBeInTheDocument();
@@ -208,7 +208,7 @@ describe("MallaCurricular — render de cards", () => {
 			getApprovedCount: vi.fn(),
 			getApprovedCredits: vi.fn(),
 			getAverage: vi.fn(),
-		} as any);
+		} as ReturnType<typeof useSubjectData>);
 
 		render(<MallaCurricular />);
 		expect(screen.getByText(/Obtenidos/i)).toBeInTheDocument();

--- a/src/pages/NexusAI.test.tsx
+++ b/src/pages/NexusAI.test.tsx
@@ -50,15 +50,15 @@ function setupMocks({
 		setGeminiApiKey: vi.fn(),
 		gmailClientId: "",
 		gmailApiKey: "",
-	} as any);
+	} as ReturnType<typeof useAetherStore>);
 
 	vi.mocked(useNexusStore).mockReturnValue({
 		documents,
-	} as any);
+	} as ReturnType<typeof useNexusStore>);
 
 	vi.mocked(useNexusDB).mockReturnValue({
 		allDatabases,
-	} as any);
+	} as ReturnType<typeof useNexusDB>);
 }
 
 // Extraer buildSystemContext para tests unitarios puros sin renderizar

--- a/src/store/aetherStore.test.ts
+++ b/src/store/aetherStore.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AetherNoteId } from "../utils/schemas";
 
 // Mock embeddings para ingestNote y semanticSearch
 vi.mock("../utils/embeddings", () => ({
@@ -77,7 +78,7 @@ describe("aetherStore — mutaciones de notas", () => {
 		expect(() =>
 			useAetherStore
 				.getState()
-				.updateNote("note_inexistente" as any, { title: "X" }),
+				.updateNote("note_inexistente" as AetherNoteId, { title: "X" }),
 		).not.toThrow();
 		expect(useAetherStore.getState().notes).toHaveLength(1);
 	});
@@ -100,7 +101,7 @@ describe("aetherStore — mutaciones de notas", () => {
 
 	it("getNote devuelve undefined para id inexistente", () => {
 		expect(
-			useAetherStore.getState().getNote("note_nada" as any),
+			useAetherStore.getState().getNote("note_nada" as AetherNoteId),
 		).toBeUndefined();
 	});
 });
@@ -164,7 +165,7 @@ describe("aetherStore — findBacklinks", () => {
 
 	it("devuelve [] si el nodo no existe", () => {
 		expect(
-			useAetherStore.getState().findBacklinks("note_ghost" as any),
+			useAetherStore.getState().findBacklinks("note_ghost" as AetherNoteId),
 		).toEqual([]);
 	});
 });
@@ -181,7 +182,7 @@ describe("aetherStore — ingestNote", () => {
 
 	it("si la nota no existe, retorna sin hacer nada", async () => {
 		useUserConfigStore.setState({ geminiApiKey: "test-key" });
-		await useAetherStore.getState().ingestNote("note_noexiste" as any);
+		await useAetherStore.getState().ingestNote("note_noexiste" as AetherNoteId);
 		expect(generateEmbedding).not.toHaveBeenCalled();
 	});
 

--- a/src/store/nexusStore.test.ts
+++ b/src/store/nexusStore.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { NexusDocumentId } from "../utils/schemas";
 
 // nexusStore usa IndexeddbPersistence de yjs — mock para no tocar IDB en tests
 vi.mock("y-indexeddb", () => ({
@@ -60,7 +61,7 @@ describe("nexusStore — mutaciones de documentos", () => {
 		expect(() =>
 			useNexusStore
 				.getState()
-				.updateDocument("doc_ghost" as any, { title: "X" }),
+				.updateDocument("doc_ghost" as NexusDocumentId, { title: "X" }),
 		).not.toThrow();
 	});
 
@@ -82,7 +83,7 @@ describe("nexusStore — mutaciones de documentos", () => {
 
 	it("getDocument retorna undefined para id inexistente", () => {
 		expect(
-			useNexusStore.getState().getDocument("doc_nada" as any),
+			useNexusStore.getState().getDocument("doc_nada" as NexusDocumentId),
 		).toBeUndefined();
 	});
 
@@ -109,7 +110,7 @@ describe("nexusStore — getYDoc y deleteDocument con YDoc", () => {
 			this: unknown,
 		) {
 			return {};
-		} as any);
+		} as unknown as typeof IndexeddbPersistence);
 	});
 	afterEach(() => {
 		localStorage.clear();

--- a/src/utils/aiUtils.test.ts
+++ b/src/utils/aiUtils.test.ts
@@ -1,4 +1,8 @@
-import type { GenerateContentParameters, Schema } from "@google/genai";
+import type {
+	GenerateContentParameters,
+	GoogleGenAI,
+	Schema,
+} from "@google/genai";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import {
@@ -34,7 +38,7 @@ describe("generateContentWithRetry", () => {
 	it("devuelve resultado en el primer intento exitoso", async () => {
 		const mockAi = {
 			models: { generateContent: vi.fn().mockResolvedValue({ text: "ok" }) },
-		} as any;
+		} as unknown as GoogleGenAI;
 
 		const result = await generateContentWithRetry(
 			mockAi,
@@ -49,7 +53,7 @@ describe("generateContentWithRetry", () => {
 		const error429 = Object.assign(new Error("rate limited"), { status: 429 });
 		const mockAi = {
 			models: { generateContent: vi.fn().mockRejectedValue(error429) },
-		} as any;
+		} as unknown as GoogleGenAI;
 
 		await expect(
 			generateContentWithRetry(mockAi, {} as GenerateContentParameters, 2),
@@ -62,7 +66,7 @@ describe("generateContentWithRetry", () => {
 		const error400 = Object.assign(new Error("bad request"), { status: 400 });
 		const mockAi = {
 			models: { generateContent: vi.fn().mockRejectedValue(error400) },
-		} as any;
+		} as unknown as GoogleGenAI;
 
 		await expect(
 			generateContentWithRetry(mockAi, {} as GenerateContentParameters, 3),
@@ -79,7 +83,7 @@ describe("generateContentWithRetry", () => {
 					.mockRejectedValueOnce(networkError)
 					.mockResolvedValueOnce({ text: "recovered" }),
 			},
-		} as any;
+		} as unknown as GoogleGenAI;
 
 		const result = await generateContentWithRetry(
 			mockAi,
@@ -97,7 +101,7 @@ describe("generateContentWithRetry", () => {
 			models: {
 				generateContent: vi.fn().mockRejectedValue(networkError),
 			},
-		} as any;
+		} as unknown as GoogleGenAI;
 
 		await expect(
 			generateContentWithRetry(mockAi, {} as GenerateContentParameters, 3),
@@ -119,7 +123,7 @@ describe("generateStructuredContentWithRetry", () => {
 					.fn()
 					.mockResolvedValue({ text: JSON.stringify({ answer: "hola" }) }),
 			},
-		} as any;
+		} as unknown as GoogleGenAI;
 
 		const result = await generateStructuredContentWithRetry(
 			mockAi,
@@ -134,7 +138,7 @@ describe("generateStructuredContentWithRetry", () => {
 	it("retorna err si el texto está vacío", async () => {
 		const mockAi = {
 			models: { generateContent: vi.fn().mockResolvedValue({ text: "" }) },
-		} as any;
+		} as unknown as GoogleGenAI;
 
 		const result = await generateStructuredContentWithRetry(
 			mockAi,
@@ -151,7 +155,7 @@ describe("generateStructuredContentWithRetry", () => {
 			models: {
 				generateContent: vi.fn().mockResolvedValue({ text: "no-es-json{" }),
 			},
-		} as any;
+		} as unknown as GoogleGenAI;
 
 		const result = await generateStructuredContentWithRetry(
 			mockAi,
@@ -170,7 +174,7 @@ describe("generateStructuredContentWithRetry", () => {
 					.fn()
 					.mockResolvedValue({ text: JSON.stringify({ wrong: 123 }) }),
 			},
-		} as any;
+		} as unknown as GoogleGenAI;
 
 		const result = await generateStructuredContentWithRetry(
 			mockAi,

--- a/src/utils/icsExport.test.ts
+++ b/src/utils/icsExport.test.ts
@@ -30,7 +30,7 @@ beforeEach(() => {
 	const origCreate = document.createElement.bind(document);
 	vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
 		if (tag === "a") return linkElement;
-		return origCreate(tag as any);
+		return origCreate(tag as Parameters<typeof document.createElement>[0]);
 	});
 
 	vi.spyOn(document.body, "appendChild").mockImplementation(() => linkElement);


### PR DESCRIPTION
## Issues cerrados

- Closes #317 (QP-01) — activityLabel switch sin default
- Closes #323 (QP-02) — activityLabel duplicada
- Closes #322 (QP-03) — tests zombie Whisper
- Closes #324 (QP-04) — comentarios obsoletos Whisper
- Closes #325 (DX-03) — as any extensivo en test files
- Closes #326 (DX-04) — sin script type-check:electron
- Closes #327 (AR-03) — cortexStore sin setIndexingProgress

## Cambios

**QP-01 + QP-02**: Nuevo módulo `src/cortex/ui/activityLabel.ts` con `default: never` exhaustiveness check. `CortexActivityIndicator` y `CortexTab` importan de ahí en lugar de duplicar la función.

**QP-03**: Eliminado `describe("SubprocessAdapter — Whisper (transcripción)")` con 2 tests zombie.

**QP-04**: `CircuitBreaker.ts` ejemplo de uso: `"whisper"` → `"docling"`. `setup.mjs`: encabezados `"Docling + Whisper"` → `"Docling"`.

**DX-03**: 39 ocurrencias de `as any` en 9 archivos de test eliminadas:
- Branded IDs: `as NexusDocumentId` / `as AetherNoteId`
- Store mocks: `as ReturnType<typeof hook>`
- AI mocks: `as unknown as GoogleGenAI`
- Constructor mock: `as unknown as typeof IndexeddbPersistence`
- `undefined as any` → `undefined`

**DX-04**: `"type-check:electron": "tsc --project tsconfig.electron.json --noEmit"` en `package.json`.

**AR-03**: `setIndexingProgress(progress: number)` en `cortexStore` — muta solo `activity.progress` cuando `activity.type === "indexing"`.

## Test plan
- [ ] `npx vitest run electron/subprocess/SubprocessAdapter.test.ts` → ✅
- [ ] `npx vitest run src/cortex/ui/` → ✅
- [ ] `npx vitest run src/store/nexusStore.test.ts src/store/aetherStore.test.ts` → ✅
- [ ] `npx tsc -p tsconfig.app.json --noEmit` → sin errores ✅
- [ ] `npx tsc -p tsconfig.electron.json --noEmit` → sin errores ✅
- [ ] `biome check .` → sin errores nuevos ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)